### PR TITLE
Pessimistic write locks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1066,6 +1066,8 @@ dependencies = [
  "moka",
  "mvclient",
  "rand",
+ "serde",
+ "serde_json",
  "stackful",
  "thiserror",
  "time",

--- a/mvsqlite-preload/preload.c
+++ b/mvsqlite-preload/preload.c
@@ -8,6 +8,7 @@
 #include <assert.h>
 
 extern void init_mvsqlite(void);
+extern void init_mvsqlite_connection(sqlite3 *db);
 
 typedef int (*sqlite3_initialize_fn)(void);
 typedef int (*sqlite3_open_v2_fn)(
@@ -40,6 +41,7 @@ int sqlite3_open_v2(
     pthread_once(&vfs_init, init_mvsqlite);
     ret = real_sqlite3_open_v2(filename, ppDb, flags, zVfs);
     if(ret == SQLITE_OK) {
+        init_mvsqlite_connection(*ppDb);
         ret = sqlite3_exec(*ppDb, "PRAGMA journal_mode = memory", NULL, NULL, NULL);
         assert(ret == SQLITE_OK);
 

--- a/mvsqlite/Cargo.toml
+++ b/mvsqlite/Cargo.toml
@@ -22,6 +22,8 @@ tracing-subscriber = { version = "0.3.15", features = ["env-filter", "fmt", "jso
 libc = "0.2"
 backtrace = "0.3.66"
 moka = "0.9.2"
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
 
 [features]
 default = ["loadext", "syscall"]

--- a/mvsqlite/src/sqlite.rs
+++ b/mvsqlite/src/sqlite.rs
@@ -1,0 +1,23 @@
+use libc::c_void;
+
+#[repr(transparent)]
+#[derive(Copy, Clone, Eq, PartialEq)]
+pub struct SqlitePtr {
+    pub ptr: *mut c_void,
+}
+
+pub type Sqlite3CommitHookCallback = unsafe extern "C" fn(data: *mut c_void) -> i32;
+pub type Sqlite3RollbackHookCallback = unsafe extern "C" fn(data: *mut c_void);
+
+extern "C" {
+    pub fn sqlite3_commit_hook(
+        s: SqlitePtr,
+        callback: Sqlite3CommitHookCallback,
+        data: *mut c_void,
+    ) -> *mut c_void;
+    pub fn sqlite3_rollback_hook(
+        s: SqlitePtr,
+        callback: Sqlite3RollbackHookCallback,
+        data: *mut c_void,
+    ) -> *mut c_void;
+}


### PR DESCRIPTION
Turns out that the commit hook is called *before* the page cache is flushed to VFS - so we can't really use it to do the commit.

Instead, in this PR a mechanism for pessimistic write locks is implemented. Exclusive transactions that are not `mvcc_aware` will acquire a lock. If there is already conflict at this stage, a `database is locked` error is returned. This is a best-effort behavior to match SQLite's standard behavior.

Fixes https://github.com/losfair/mvsqlite/issues/2.
