### PR TITLE
Managed page cache

### DIFF
--- a/mvsqlite-preload/shim.c
+++ b/mvsqlite-preload/shim.c
@@ -51,10 +51,6 @@ int sqlite3_open_v2(
     ret = real_sqlite3_open_v2(filename, ppDb, flags, zVfs);
     if(ret == SQLITE_OK && mvsqlite_enabled) {
         init_mvsqlite_connection(*ppDb);
-
-        // Return code ignored - this can fail if the database doesn't exist, and we can't really
-        // do anything about it.
-        sqlite3_exec(*ppDb, "PRAGMA cache_size = -50000", NULL, NULL, NULL);
     }
     return ret;
 }

--- a/mvsqlite/src/lib.rs
+++ b/mvsqlite/src/lib.rs
@@ -8,7 +8,7 @@ pub mod sqlite_vfs;
 pub mod tempfile;
 pub mod vfs;
 
-use std::sync::Arc;
+use std::sync::{atomic::Ordering, Arc};
 
 use crate::{io_engine::IoEngine, vfs::MultiVersionVfs};
 
@@ -42,6 +42,12 @@ fn init_with_options_impl(opts: InitOptions) {
             panic!("MVSQLITE_SECTOR_SIZE must be one of 4096, 8192, 16384, 32768");
         }
         sector_size = requested_ss;
+    }
+    if let Ok(s) = std::env::var("MVSQLITE_PAGE_CACHE_SIZE") {
+        let requested = s
+            .parse::<usize>()
+            .expect("MVSQLITE_PAGE_CACHE_SIZE must be a usize");
+        vfs::PAGE_CACHE_SIZE.store(requested, Ordering::Relaxed);
     }
 
     let data_plane = std::env::var("MVSQLITE_DATA_PLANE").expect("MVSQLITE_DATA_PLANE is not set");

--- a/mvstore-stress/src/inmem.rs
+++ b/mvstore-stress/src/inmem.rs
@@ -63,21 +63,14 @@ impl Inmem {
             num_prev_versions += 1;
         }
 
-        let this_rw_set: HashSet<u32> = this
-            .read_set
-            .iter()
-            .copied()
-            .chain(this.write_set.iter().copied())
-            .collect();
-
         // Ensure no intersection
         if write_set
             .iter()
             .copied()
-            .chain(this_rw_set.iter().copied())
+            .chain(this.read_set.iter().copied())
             .collect::<HashSet<_>>()
             .len()
-            != write_set.len() + this_rw_set.len()
+            != write_set.len() + this.read_set.len()
         {
             panic!("conflict detected");
         }

--- a/mvstore-stress/src/tester.rs
+++ b/mvstore-stress/src/tester.rs
@@ -193,7 +193,10 @@ impl Tester {
                     if reads.len() == 0 {
                         continue;
                     }
-                    let pages = txn.read_many(&reads).await?;
+                    for &id in &reads {
+                        txn.mark_read(id);
+                    }
+                    let pages = txn.read_many_nomark(&reads).await?;
                     let mut mem = self.mem.write().await;
                     for (&index, page) in reads.iter().zip(pages.iter()) {
                         tracing::debug!(

--- a/mvstore/src/commit.rs
+++ b/mvstore/src/commit.rs
@@ -69,7 +69,7 @@ impl Server {
             && ctx
                 .namespaces
                 .iter()
-                .map(|x| x.read_set.len() + x.index_writes.len())
+                .map(|x| x.read_set.len())
                 .sum::<usize>()
                 <= PLCC_READ_SET_SIZE_THRESHOLD.load(Ordering::Relaxed);
         let mut commit_token = [0u8; 16];
@@ -172,13 +172,7 @@ impl Server {
             // Fine-grained conflict check
             if plcc_enable_ns {
                 let mut fut_list = FuturesOrdered::new();
-                let check_set: HashSet<u32> = ns
-                    .read_set
-                    .iter()
-                    .copied()
-                    .chain(ns.index_writes.iter().map(|x| x.0))
-                    .collect();
-                for &page in &check_set {
+                for &page in &ns.read_set {
                     let read_page_hash_fut = self.read_page_hash(&txn, ns.ns_id, page, None);
                     fut_list.push(async move { (page, read_page_hash_fut.await) });
                 }


### PR DESCRIPTION
Previously we relied on SQLite's page cache subsystem to cache reads across transactions. This breaks PLCC correctness, as it was not possible to track the read set.

This PR implements page cache on mvsqlite side.