### PR TITLE
mvfs: Replace moka with lru due to memory leak

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
+name = "ahash"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcb51a0695d8f838b1ee009b3fbf66bda078cd64590202a864a8f3e8c4315c47"
+dependencies = [
+ "getrandom",
+ "once_cell",
+ "version_check",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -842,6 +853,9 @@ name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+dependencies = [
+ "ahash",
+]
 
 [[package]]
 name = "heapless"
@@ -1101,6 +1115,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "lru"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e999beba7b6e8345721bd280141ed958096a2e4abdf74f67ff4ce49b4b54e47a"
+dependencies = [
+ "hashbrown",
+]
+
+[[package]]
 name = "mach"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1227,7 +1250,7 @@ version = "0.1.16"
 dependencies = [
  "anyhow",
  "lazy_static",
- "moka",
+ "lru",
  "mvclient",
  "reqwest",
  "serde",

--- a/mvfs/Cargo.toml
+++ b/mvfs/Cargo.toml
@@ -16,8 +16,8 @@ thiserror = "1"
 tokio = { version = "1", features = ["full"] }
 mvclient = { path = "../mvclient" }
 tracing = "0.1"
-moka = "0.9.3"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 lazy_static = "1.4.0"
 reqwest = { version = "0.11.11", default-features = false } # the dependent crate should set its own features
+lru = "0.7.8"


### PR DESCRIPTION
Seems that the `moka` crate has a memory leak issue when `moka::sync::Cache` is dropped. Detected in production, and confirmed with Valgrind:

```
==905778== 82,960 (560 direct, 82,400 indirect) bytes in 10 blocks are definitely lost in loss record 194 of 199
==905778==    at 0x483B7F3: malloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==905778==    by 0x503005B: moka::sync_base::base_cache::BaseCache<K,V,S>::do_insert_with_hash::{{closure}} (in /home/ubuntu/Projects/mvsqlite/mvsqlite-preload/libmvsqlite_preload.so)
==905778==    by 0x502FD32: moka::cht::map::bucket::InsertOrModifyState<K,V,F>::into_insert_bucket (in /home/ubuntu/Projects/mvsqlite/mvsqlite-preload/libmvsqlite_preload.so)
==905778==    by 0x502CF77: moka::cht::map::bucket::BucketArray<K,V>::insert_or_modify (in /home/ubuntu/Projects/mvsqlite/mvsqlite-preload/libmvsqlite_preload.so)
==905778==    by 0x4BC49EE: moka::cht::map::bucket_array_ref::BucketArrayRef<K,V,S>::insert_with_or_modify_entry_and (in /home/ubuntu/Projects/mvsqlite/mvsqlite-preload/libmvsqlite_preload.so)
==905778==    by 0x503A7F6: moka::sync::cache::Cache<K,V,S>::insert (in /home/ubuntu/Projects/mvsqlite/mvsqlite-preload/libmvsqlite_preload.so)
==905778==    by 0x4BC8DDB: mvfs::vfs::Connection::insert_to_page_cache (in /home/ubuntu/Projects/mvsqlite/mvsqlite-preload/libmvsqlite_preload.so)
==905778==    by 0x4B08D3A: <core::future::from_generator::GenFuture<T> as core::future::future::Future>::poll (in /home/ubuntu/Projects/mvsqlite/mvsqlite-preload/libmvsqlite_preload.so)
==905778==    by 0x4B0A24A: _ZN97_$LT$core..future..from_generator..GenFuture$LT$T$GT$$u20$as$u20$core..future..future..Future$GT$4poll17h50e20491b908d0c9E.llvm.3961465344180881740 (in /home/ubuntu/Projects/mvsqlite/mvsqlite-preload/libmv
sqlite_preload.so)
==905778==    by 0x4B1042B: <core::future::from_generator::GenFuture<T> as core::future::future::Future>::poll (in /home/ubuntu/Projects/mvsqlite/mvsqlite-preload/libmvsqlite_preload.so)
==905778==    by 0x4A722A2: std::thread::local::LocalKey<T>::with (in /home/ubuntu/Projects/mvsqlite/mvsqlite-preload/libmvsqlite_preload.so)
==905778==    by 0x4A97131: tokio::park::thread::CachedParkThread::block_on (in /home/ubuntu/Projects/mvsqlite/mvsqlite-preload/libmvsqlite_preload.so)
==905778==
==905778== 165,920 (1,120 direct, 164,800 indirect) bytes in 20 blocks are definitely lost in loss record 197 of 199
==905778==    at 0x483B7F3: malloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==905778==    by 0x503005B: moka::sync_base::base_cache::BaseCache<K,V,S>::do_insert_with_hash::{{closure}} (in /home/ubuntu/Projects/mvsqlite/mvsqlite-preload/libmvsqlite_preload.so)
==905778==    by 0x502FD32: moka::cht::map::bucket::InsertOrModifyState<K,V,F>::into_insert_bucket (in /home/ubuntu/Projects/mvsqlite/mvsqlite-preload/libmvsqlite_preload.so)
==905778==    by 0x502CF77: moka::cht::map::bucket::BucketArray<K,V>::insert_or_modify (in /home/ubuntu/Projects/mvsqlite/mvsqlite-preload/libmvsqlite_preload.so)
==905778==    by 0x4BC49EE: moka::cht::map::bucket_array_ref::BucketArrayRef<K,V,S>::insert_with_or_modify_entry_and (in /home/ubuntu/Projects/mvsqlite/mvsqlite-preload/libmvsqlite_preload.so)
==905778==    by 0x503A7F6: moka::sync::cache::Cache<K,V,S>::insert (in /home/ubuntu/Projects/mvsqlite/mvsqlite-preload/libmvsqlite_preload.so)
==905778==    by 0x4BC8DDB: mvfs::vfs::Connection::insert_to_page_cache (in /home/ubuntu/Projects/mvsqlite/mvsqlite-preload/libmvsqlite_preload.so)
==905778==    by 0x4B08D3A: <core::future::from_generator::GenFuture<T> as core::future::future::Future>::poll (in /home/ubuntu/Projects/mvsqlite/mvsqlite-preload/libmvsqlite_preload.so)
==905778==    by 0x4B0A24A: _ZN97_$LT$core..future..from_generator..GenFuture$LT$T$GT$$u20$as$u20$core..future..future..Future$GT$4poll17h50e20491b908d0c9E.llvm.3961465344180881740 (in /home/ubuntu/Projects/mvsqlite/mvsqlite-preload/libmv
sqlite_preload.so)
==905778==    by 0x4B11852: <core::future::from_generator::GenFuture<T> as core::future::future::Future>::poll (in /home/ubuntu/Projects/mvsqlite/mvsqlite-preload/libmvsqlite_preload.so)
==905778==    by 0x4A717CC: std::thread::local::LocalKey<T>::with (in /home/ubuntu/Projects/mvsqlite/mvsqlite-preload/libmvsqlite_preload.so)
==905778==    by 0x4A96D7E: tokio::park::thread::CachedParkThread::block_on (in /home/ubuntu/Projects/mvsqlite/mvsqlite-preload/libmvsqlite_preload.so)
==905778==
```

This PR replaces `moka` with `lru` to resolve the issue.