### PR TITLE
Enforce non-executable stack when linking shared library.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
           set -e
           curl -L https://github.com/apple/foundationdb/releases/download/7.1.17/foundationdb-clients_7.1.17-1_amd64.deb --output fdb-client.deb
           sudo dpkg -i fdb-client.deb
-          sudo apt update && sudo apt install -y libfuse3-dev
+          sudo apt update && sudo apt install -y libfuse3-dev execstack
       - name: Build (mvstore)
         run: cargo build --release -p mvstore
       - name: Build (mvsqlite)
@@ -46,6 +46,11 @@ jobs:
           cp ../mvsqlite-preload/libmvsqlite_preload.so ./
           cp ../mvsqlite-preload/libmvsqlite.a ./
           find . -type f -exec sha256sum '{}' ';'
+      - name: Check binaries
+        run: |
+          set -e
+          execstack -q ./build/libmvsqlite_preload.so | tee execstack.log
+          grep -v '^X ' execstack.log
       - name: Push binaries
         uses: actions/upload-artifact@v3
         with:

--- a/mvsqlite-preload/Makefile
+++ b/mvsqlite-preload/Makefile
@@ -1,7 +1,11 @@
 CFLAGS += -O2 -fPIC
 
 build-preload: preload.o shim.o
-	$(CC) -O2 -shared -o libmvsqlite_preload.so preload.o shim.o -L../target/release -lmvsqlite -lsqlite3 -lssl -lcrypto -lpthread -ldl -lm
+	$(CC) -O2 -shared \
+		-Wl,-z,noexecstack \
+		-o libmvsqlite_preload.so \
+		preload.o shim.o \
+		-L../target/release -lmvsqlite -lsqlite3 -lssl -lcrypto -lpthread -ldl -lm
 
 build-lib: shim.o
 	ar rcs libmvsqlite.a shim.o


### PR DESCRIPTION
Related: https://github.com/losfair/mvsqlite/issues/63