### PR TITLE
Replace lru with moka

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,17 +18,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
-name = "ahash"
-version = "0.7.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcb51a0695d8f838b1ee009b3fbf66bda078cd64590202a864a8f3e8c4315c47"
-dependencies = [
- "getrandom",
- "once_cell",
- "version_check",
-]
-
-[[package]]
 name = "aho-corasick"
 version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -853,9 +842,6 @@ name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
-dependencies = [
- "ahash",
-]
 
 [[package]]
 name = "heapless"
@@ -1116,15 +1102,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "lru"
-version = "0.7.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e999beba7b6e8345721bd280141ed958096a2e4abdf74f67ff4ce49b4b54e47a"
-dependencies = [
- "hashbrown",
-]
-
-[[package]]
 name = "mach"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1198,9 +1175,9 @@ dependencies = [
 
 [[package]]
 name = "moka"
-version = "0.9.3"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a89c33e91526792a0260425073c3db0b472cdca2cc6fcaa666dd6e65450462a"
+checksum = "dd8256cf9fa396576521e5e94affadb95818ec48f5dbedca36714387688aea29"
 dependencies = [
  "async-io",
  "async-lock",
@@ -1251,7 +1228,7 @@ version = "0.1.18"
 dependencies = [
  "anyhow",
  "lazy_static",
- "lru",
+ "moka",
  "mvclient",
  "reqwest",
  "serde",

--- a/mvfs/Cargo.toml
+++ b/mvfs/Cargo.toml
@@ -20,4 +20,4 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 lazy_static = "1.4.0"
 reqwest = { version = "0.11.11", default-features = false } # the dependent crate should set its own features
-lru = "0.7.8"
+moka = { version = "0.9.4" }

--- a/mvstore/Cargo.toml
+++ b/mvstore/Cargo.toml
@@ -40,7 +40,7 @@ blake3 = "1.3.1"
 serde_json = "1"
 serde_bytes = "0.11"
 zstd = "0.11.2"
-moka = { version = "0.9.3", features = ["future"] }
+moka = { version = "0.9.4", features = ["future"] }
 bloom = "0.3.2"
 constant_time_eq = "0.2.4"
 heapless = { version = "0.7", features = ["serde"] }


### PR DESCRIPTION
Now the memory leak issue in `moka` is fixed (related: https://github.com/moka-rs/moka/issues/176), add it back.

Benchmarks indicate that `moka` has a performance advantage.