### PR TITLE
Retry conflicted autocommits.

### DIFF
--- a/mvsqlite-preload/sqlite-3390300.patch
+++ b/mvsqlite-preload/sqlite-3390300.patch
@@ -1,5 +1,5 @@
---- sqlite3.c	2022-09-05 11:28:58.000000000 +0000
-+++ sqlite3-mv.c	2022-09-23 13:02:17.876434507 +0000
+--- sqlite3.c   2022-09-05 11:28:58.000000000 +0000
++++ sqlite3-mv.c        2022-10-07 08:03:02.699008373 +0000
 @@ -3931,7 +3931,7 @@
    const void *filename,   /* Database filename (UTF-16) */
    sqlite3 **ppDb          /* OUT: SQLite db handle */
@@ -9,7 +9,24 @@
    const char *filename,   /* Database filename (UTF-8) */
    sqlite3 **ppDb,         /* OUT: SQLite db handle */
    int flags,              /* Flags */
-@@ -130545,7 +130545,7 @@
+@@ -5132,6 +5132,7 @@
+ ** by sqlite3_step().  The use of the "vX" interfaces is recommended.
+ */
+ SQLITE_API int sqlite3_step(sqlite3_stmt*);
++SQLITE_API int real_sqlite3_step(sqlite3_stmt*);
+ 
+ /*
+ ** CAPI3REF: Number of columns in a result set
+@@ -86778,7 +86779,7 @@
+ ** sqlite3Step() to do most of the work.  If a schema error occurs,
+ ** call sqlite3Reprepare() and try again.
+ */
+-SQLITE_API int sqlite3_step(sqlite3_stmt *pStmt){
++SQLITE_API int real_sqlite3_step(sqlite3_stmt *pStmt){
+   int rc = SQLITE_OK;      /* Result from sqlite3Step() */
+   Vdbe *v = (Vdbe*)pStmt;  /* the prepared statement */
+   int cnt = 0;             /* Counter to prevent infinite loop of reprepares */
+@@ -130545,7 +130546,7 @@
    sqlite3_mutex_leave,
    sqlite3_mutex_try,
  #endif
@@ -18,7 +35,7 @@
    sqlite3_release_memory,
    sqlite3_result_error_nomem,
    sqlite3_result_error_toobig,
-@@ -174158,17 +174158,7 @@
+@@ -174158,17 +174159,7 @@
  }
  
  

--- a/mvsqlite/src/lib.rs
+++ b/mvsqlite/src/lib.rs
@@ -330,3 +330,12 @@ unsafe extern "C" fn mv_unpin_version(
         }
     }
 }
+
+#[no_mangle]
+pub unsafe extern "C" fn mvsqlite_autocommit_backoff(db: *mut sqlite_c::sqlite3) {
+    tracing::warn!("autocommit backoff");
+    let conn = get_conn(db, "main");
+    conn.io.run(async {
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    });
+}


### PR DESCRIPTION
Applications don't like `SQLITE_BUSY` returned from `sqlite3_step` outside transactions. Let's hack it.