### PR TITLE
Online DDL - stage 1

### DIFF
--- a/mvsqlite-fuse/src/main.rs
+++ b/mvsqlite-fuse/src/main.rs
@@ -96,6 +96,7 @@ async fn main() -> Result<()> {
         sector_size: opt.sector_size,
         http_client: reqwest::Client::new(),
         db_name_map: Arc::new(Default::default()),
+        lock_owner: None,
     };
     let fuse_fs = FuseFs {
         namespaces,

--- a/mvsqlite/src/lib.rs
+++ b/mvsqlite/src/lib.rs
@@ -101,6 +101,14 @@ fn init_with_options_impl(opts: InitOptions) {
     }
     let db_name_map = Arc::new(db_name_map);
 
+    let mut lock_owner: Option<String> = None;
+    if let Ok(s) = std::env::var("MVSQLITE_LOCK_OWNER") {
+        if !s.is_empty() {
+            tracing::debug!(lock_owner = s, "configuring lock owner");
+            lock_owner = Some(s);
+        }
+    }
+
     let mut builder = reqwest::ClientBuilder::new();
     builder = builder.timeout(Duration::from_secs(timeout_secs));
     if force_http2 {
@@ -118,6 +126,7 @@ fn init_with_options_impl(opts: InitOptions) {
             sector_size,
             http_client: http_client.clone(),
             db_name_map: db_name_map.clone(),
+            lock_owner: lock_owner.clone(),
         },
     };
 
@@ -131,6 +140,7 @@ fn init_with_options_impl(opts: InitOptions) {
                 sector_size,
                 http_client: http_client.clone(),
                 db_name_map: db_name_map.clone(),
+                lock_owner: lock_owner.clone(),
             },
         };
         sqlite_vfs::register(&format!("{}-{}", VFS_NAME, sector_size), vfs, false)

--- a/mvstore-stress/src/main.rs
+++ b/mvstore-stress/src/main.rs
@@ -79,6 +79,7 @@ async fn main() -> Result<()> {
             data_plane: vec![opt.data_plane.parse()?],
             ns_key: opt.ns_key.clone(),
             ns_key_hashproof: None,
+            lock_owner: None,
         },
         reqwest::Client::new(),
     )?;

--- a/mvstore/src/commit.rs
+++ b/mvstore/src/commit.rs
@@ -197,6 +197,10 @@ impl Server {
                         return Ok(CommitResult::Conflict);
                     }
                 }
+            } else {
+                if ctx.lock_owner.is_some() {
+                    return Err(GoneError("you do not own the lock").into());
+                }
             }
 
             let mut written_pages: BTreeSet<u32> = BTreeSet::new();

--- a/mvstore/src/commit.rs
+++ b/mvstore/src/commit.rs
@@ -16,7 +16,7 @@ use rand::RngCore;
 use crate::{
     delta::reader::DeltaReader,
     server::Server,
-    util::{decode_version, generate_suffix_versionstamp_atomic_op},
+    util::{decode_version, generate_suffix_versionstamp_atomic_op, GoneError},
     util::{get_txn_read_version_as_versionstamp, ContentIndex},
     write::{WriteApplier, WriteApplierContext, WriteRequest},
 };
@@ -39,6 +39,7 @@ pub struct CommitContext<'a> {
     pub idempotency_key: [u8; 16],
     pub allow_skip_idempotency_check: bool,
     pub namespaces: &'a [CommitNamespaceContext<'a>],
+    pub lock_owner: Option<&'a str>,
 }
 
 pub struct CommitNamespaceContext<'a> {
@@ -175,9 +176,27 @@ impl Server {
         // Phase 2 - content index insertion
 
         for ns in ctx.namespaces {
-            if let Some(md) = &ns.metadata {
-                let metadata_key = self.key_codec.construct_nsmd_key(ns.ns_id);
-                txn.set(&metadata_key, md.as_bytes());
+            let metadata = self
+                .ns_metadata_cache
+                .get(&txn, &self.key_codec, ns.ns_id)
+                .await?;
+
+            // Does the client own the lock, if any?
+            if let Some(lock) = &metadata.lock {
+                match ctx.lock_owner {
+                    Some(lock_owner) => {
+                        // Validate lock ownership and state
+                        if lock.owner.as_str() != lock_owner {
+                            return Err(GoneError("you no longer own the lock").into());
+                        }
+                        if lock.rolling_back {
+                            return Err(GoneError("rolling back").into());
+                        }
+                    }
+                    None => {
+                        return Ok(CommitResult::Conflict);
+                    }
+                }
             }
 
             let mut written_pages: BTreeSet<u32> = BTreeSet::new();

--- a/mvstore/src/delta/reader.rs
+++ b/mvstore/src/delta/reader.rs
@@ -34,14 +34,6 @@ impl<'a> DeltaReader<'a> {
             Some(x) => decode_version(x)?,
             None => [0xffu8; 10],
         };
-        if let Some(rm) = self.replica_manager {
-            let current_rv = rm.replica_version(self.txn).await?;
-            let requested_rv = i64::from_be_bytes(page_version[0..8].try_into().unwrap());
-            if current_rv < requested_rv {
-                anyhow::bail!("this replica does not have the requested read version");
-            }
-            tracing::debug!(current_rv, requested_rv, "read_page_hash replica read");
-        }
         let scan_end = self
             .key_codec
             .construct_page_key(self.ns_id, page_index, page_version);

--- a/mvstore/src/gc.rs
+++ b/mvstore/src/gc.rs
@@ -15,8 +15,8 @@ use crate::{
     lock::DistributedLock,
     server::Server,
     util::{
-        add_single_key_read_conflict_range, decode_version, get_txn_read_version_as_versionstamp,
-        ContentIndex,
+        add_single_key_read_conflict_range, decode_version, extract_10_byte_suffix,
+        get_txn_read_version_as_versionstamp, truncate_10_byte_suffix, ContentIndex,
     },
 };
 
@@ -470,14 +470,4 @@ impl Server {
         progress_callback(format!("DONE\n"));
         Ok(())
     }
-}
-
-fn truncate_10_byte_suffix(data: &[u8]) -> &[u8] {
-    assert!(data.len() >= 10);
-    &data[..data.len() - 10]
-}
-
-fn extract_10_byte_suffix(data: &[u8]) -> [u8; 10] {
-    assert!(data.len() >= 10);
-    <[u8; 10]>::try_from(&data[data.len() - 10..]).unwrap()
 }

--- a/mvstore/src/keys.rs
+++ b/mvstore/src/keys.rs
@@ -15,6 +15,13 @@ impl KeyCodec {
         key
     }
 
+    pub fn construct_nsrollbackcursor_key(&self, ns_id: [u8; 10]) -> Vec<u8> {
+        let mut key = pack(&(self.metadata_prefix.as_str(), "nsrollbackcursor"));
+        key.push(0x32);
+        key.extend_from_slice(&ns_id);
+        key
+    }
+
     pub fn construct_nstask_key(&self, ns_id: [u8; 10], task: &str) -> Vec<u8> {
         let mut key = pack(&(self.metadata_prefix.as_str(), "nstask"));
         key.push(0x32);

--- a/mvstore/src/main.rs
+++ b/mvstore/src/main.rs
@@ -4,6 +4,7 @@ mod fixed;
 mod gc;
 mod keys;
 mod lock;
+mod metadata;
 mod page;
 mod replica;
 mod server;

--- a/mvstore/src/main.rs
+++ b/mvstore/src/main.rs
@@ -5,6 +5,7 @@ mod gc;
 mod keys;
 mod lock;
 mod metadata;
+mod nslock;
 mod page;
 mod replica;
 mod server;

--- a/mvstore/src/metadata.rs
+++ b/mvstore/src/metadata.rs
@@ -7,12 +7,12 @@ use serde::{Deserialize, Serialize};
 
 use crate::keys::KeyCodec;
 
-#[derive(Serialize, Deserialize, Default)]
+#[derive(Serialize, Deserialize, Default, Clone)]
 pub struct NamespaceMetadata {
     pub lock: Option<NamespaceLock>,
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, Clone)]
 pub struct NamespaceLock {
     pub snapshot_version: String,
     pub owner: String,

--- a/mvstore/src/metadata.rs
+++ b/mvstore/src/metadata.rs
@@ -1,0 +1,76 @@
+use std::{sync::Arc, time::Duration};
+
+use anyhow::Result;
+use foundationdb::Transaction;
+use moka::future::Cache;
+use serde::{Deserialize, Serialize};
+
+use crate::keys::KeyCodec;
+
+#[derive(Serialize, Deserialize, Default)]
+pub struct NamespaceMetadata {
+    pub lock: Option<NamespaceLock>,
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct NamespaceLock {
+    pub snapshot_version: String,
+    pub owner: String,
+}
+
+pub struct NamespaceMetadataCache {
+    cache: Cache<(i64, [u8; 10]), Arc<NamespaceMetadata>>,
+}
+
+impl NamespaceMetadataCache {
+    pub fn new() -> Self {
+        Self {
+            cache: Cache::builder()
+                .time_to_idle(Duration::from_secs(30))
+                .max_capacity(1000)
+                .build(),
+        }
+    }
+
+    pub async fn get(
+        &self,
+        txn: &Transaction,
+        key_codec: &KeyCodec,
+        ns_id: [u8; 10],
+    ) -> Result<Arc<NamespaceMetadata>> {
+        let metadata_version = txn.get_metadata_version(false).await?.unwrap_or(0);
+        let cached: Arc<NamespaceMetadata> = self
+            .cache
+            .try_get_with((metadata_version, ns_id), async {
+                let key = key_codec.construct_nsmd_key(ns_id);
+
+                // Snapshot read is correct here because `metadata_version` read already guards against concurrent mutations
+                let metadata = txn.get(&key, true).await;
+
+                match metadata {
+                    Ok(x) => Ok(Arc::new(
+                        serde_json::from_slice(x.as_ref().map(|x| &x[..]).unwrap_or_default())
+                            .unwrap_or_default(),
+                    )),
+                    Err(e) => Err(e),
+                }
+            })
+            .await?;
+        Ok(cached)
+    }
+
+    pub fn set(
+        &self,
+        txn: &Transaction,
+        key_codec: &KeyCodec,
+        ns_id: [u8; 10],
+        metadata: Arc<NamespaceMetadata>,
+    ) -> Result<()> {
+        txn.set(
+            &key_codec.construct_nsmd_key(ns_id),
+            &serde_json::to_vec(&*metadata)?,
+        );
+        txn.update_metadata_version();
+        Ok(())
+    }
+}

--- a/mvstore/src/nslock.rs
+++ b/mvstore/src/nslock.rs
@@ -1,16 +1,28 @@
-use std::sync::Arc;
+use std::sync::{
+    atomic::{AtomicUsize, Ordering},
+    Arc,
+};
 
 use crate::{
+    fixed::FixedKeyVec,
     keys::KeyCodec,
     metadata::{NamespaceLock, NamespaceMetadataCache},
-    util::get_last_write_version,
+    util::{
+        extract_10_byte_suffix, extract_beu32_suffix, get_last_write_version,
+        truncate_10_byte_suffix,
+    },
 };
 use anyhow::Result;
-use foundationdb::Database;
+use foundationdb::{
+    options::{MutationType, StreamingMode},
+    Database, RangeOption, Transaction,
+};
 use hyper::{Body, Response};
+use rand::Rng;
 use serde::Deserialize;
 
 const MAX_OWNER_STR_BYTE_SIZE: usize = 256;
+pub static NSLOCK_ROLLBACK_SCAN_BATCH_SIZE: AtomicUsize = AtomicUsize::new(1000);
 
 #[derive(Deserialize, Copy, Clone)]
 pub enum NslockReleaseMode {
@@ -50,9 +62,14 @@ pub async fn acquire_nslock(
         }
 
         let lwv = get_last_write_version(&txn, key_codec, ns_id, false).await?;
+
+        let mut nonce: [u8; 16] = [0u8; 16];
+        rand::thread_rng().fill(&mut nonce);
+
         metadata.lock = Some(NamespaceLock {
             snapshot_version: hex::encode(&lwv),
             owner: owner.to_string(),
+            nonce: hex::encode(&nonce),
             rolling_back: false,
         });
         ns_metadata_cache.set(&txn, key_codec, ns_id, Arc::new(metadata))?;
@@ -61,14 +78,7 @@ pub async fn acquire_nslock(
                 return Ok(Response::builder().status(201).body(Body::empty())?);
             }
             Err(e) => {
-                txn = match e.on_error().await {
-                    Ok(x) => x,
-                    Err(e) => {
-                        return Ok(Response::builder()
-                            .status(400)
-                            .body(Body::from(format!("{}", e)))?)
-                    }
-                };
+                txn = e.on_error().await?;
             }
         }
     }
@@ -88,7 +98,12 @@ pub async fn release_nslock(
             .body(Body::from("invalid owner\n"))?);
     }
 
+    let rollback_cursor_key = key_codec.construct_nsrollbackcursor_key(ns_id);
+
     let mut txn = db.create_trx()?;
+    let nonce: String;
+    let snapshot_version: [u8; 10];
+
     loop {
         let metadata = ns_metadata_cache.get(&txn, key_codec, ns_id).await?;
         let mut metadata = (*metadata).clone();
@@ -119,14 +134,7 @@ pub async fn release_nslock(
                         return Ok(Response::builder().status(201).body(Body::empty())?);
                     }
                     Err(e) => {
-                        txn = match e.on_error().await {
-                            Ok(x) => x,
-                            Err(e) => {
-                                return Ok(Response::builder()
-                                    .status(400)
-                                    .body(Body::from(format!("{}", e)))?)
-                            }
-                        };
+                        txn = e.on_error().await?;
                         continue;
                     }
                 }
@@ -136,22 +144,21 @@ pub async fn release_nslock(
                 // Rollback mode: first mark this lock as being rolled back.
                 if !lock.rolling_back {
                     lock.rolling_back = true;
-                    ns_metadata_cache.set(&txn, key_codec, ns_id, Arc::new(metadata))?;
+                    let metadata = Arc::new(metadata);
+                    ns_metadata_cache.set(&txn, key_codec, ns_id, metadata.clone())?;
+                    txn.clear(&rollback_cursor_key);
 
                     match txn.commit().await {
                         Ok(output) => {
                             txn = output.reset();
+                            nonce = metadata.lock.as_ref().unwrap().nonce.clone();
+                            snapshot_version = <[u8; 10]>::try_from(
+                                &hex::decode(&metadata.lock.as_ref().unwrap().snapshot_version)?[..],
+                            )?;
                             break;
                         }
                         Err(e) => {
-                            txn = match e.on_error().await {
-                                Ok(x) => x,
-                                Err(e) => {
-                                    return Ok(Response::builder()
-                                        .status(400)
-                                        .body(Body::from(format!("{}", e)))?)
-                                }
-                            };
+                            txn = e.on_error().await?;
                             continue;
                         }
                     }
@@ -161,6 +168,135 @@ pub async fn release_nslock(
     }
 
     // We get here when rollback is required
+    // Scan and delete
+    let mut total_count = 0u64;
+
+    // Snapshot read is correct here - running through a range twice is fine
+    let mut rollback_cursor = u32::from_le_bytes(
+        txn.get(&rollback_cursor_key, true)
+            .await?
+            .and_then(|x| <[u8; 4]>::try_from(&x[..]).ok())
+            .unwrap_or_default(),
+    );
+    let scan_end = key_codec.construct_page_key(ns_id, std::u32::MAX, [0xffu8; 10]);
+    let mut scan_cursor = key_codec.construct_page_key(ns_id, rollback_cursor, [0u8; 10]);
+
+    loop {
+        let valid = lock_is_still_valid(&txn, key_codec, ns_metadata_cache, ns_id, &nonce).await?;
+        if !valid {
+            return Ok(Response::builder()
+                .status(410)
+                .body(Body::from("lock is gone"))?);
+        }
+
+        // Snapshot read is correct here because conflict range added by lock_is_still_valid is enough
+        let scan_result = txn
+            .get_range(
+                &RangeOption {
+                    limit: Some(NSLOCK_ROLLBACK_SCAN_BATCH_SIZE.load(Ordering::Relaxed)),
+                    reverse: false,
+                    mode: StreamingMode::WantAll,
+                    ..RangeOption::from(scan_cursor.as_slice()..=scan_end.as_slice())
+                },
+                0,
+                true,
+            )
+            .await?;
+
+        let mut delete_count: usize = 0;
+
+        for entry in &scan_result[..] {
+            let version = extract_10_byte_suffix(entry.key());
+            if version > snapshot_version {
+                txn.clear(entry.key());
+                delete_count += 1;
+            }
+        }
+
+        if scan_result.is_empty() {
+            // Done
+            txn.reset();
+            break;
+        }
+
+        let last_key = scan_result.last().unwrap().key().to_vec();
+        let new_rollback_cursor = extract_beu32_suffix(truncate_10_byte_suffix(&last_key));
+        if new_rollback_cursor > rollback_cursor {
+            txn.atomic_op(
+                &rollback_cursor_key,
+                &rollback_cursor.to_le_bytes(),
+                MutationType::Max,
+            );
+        }
+
+        match txn.commit().await {
+            Ok(output) => {
+                txn = output.reset();
+                total_count += delete_count as u64;
+                rollback_cursor = new_rollback_cursor;
+                scan_cursor = FixedKeyVec::from_slice(&last_key).unwrap();
+                scan_cursor.push(0).unwrap();
+            }
+            Err(e) => {
+                txn = e.on_error().await?;
+            }
+        }
+    }
+
+    loop {
+        let valid = lock_is_still_valid(&txn, key_codec, ns_metadata_cache, ns_id, &nonce).await?;
+        if !valid {
+            return Ok(Response::builder()
+                .status(410)
+                .body(Body::from("lock is gone"))?);
+        }
+
+        // Patch LWV
+        {
+            let last_write_version_key = key_codec.construct_last_write_version_key(ns_id);
+
+            let mut new_lwv_value = [0u8; 16 + 10];
+            new_lwv_value[16..26].copy_from_slice(&snapshot_version);
+            txn.set(&last_write_version_key, &new_lwv_value);
+        }
+
+        // Delete changelog
+        {
+            let mut start = key_codec.construct_changelog_key(ns_id, snapshot_version);
+            let end = key_codec.construct_changelog_key(ns_id, [0xffu8; 10]);
+            start.push(0).unwrap();
+            txn.clear_range(start.as_slice(), end.as_slice());
+        }
+
+        // Unlock
+        let metadata = ns_metadata_cache.get(&txn, key_codec, ns_id).await?;
+        let mut metadata = (*metadata).clone();
+        metadata.lock = None;
+        ns_metadata_cache.set(&txn, key_codec, ns_id, Arc::new(metadata))?;
+
+        match txn.commit().await {
+            Ok(_) => break,
+            Err(e) => {
+                txn = e.on_error().await?;
+            }
+        }
+    }
 
     Ok(Response::builder().status(200).body(Body::empty())?)
+}
+
+async fn lock_is_still_valid(
+    txn: &Transaction,
+    key_codec: &KeyCodec,
+    ns_metadata_cache: &NamespaceMetadataCache,
+    ns_id: [u8; 10],
+    nonce: &str,
+) -> Result<bool> {
+    let metadata = ns_metadata_cache.get(&txn, key_codec, ns_id).await?;
+    if let Some(lock) = &metadata.lock {
+        if lock.nonce == nonce {
+            return Ok(true);
+        }
+    }
+    Ok(false)
 }

--- a/mvstore/src/nslock.rs
+++ b/mvstore/src/nslock.rs
@@ -1,0 +1,166 @@
+use std::sync::Arc;
+
+use crate::{
+    keys::KeyCodec,
+    metadata::{NamespaceLock, NamespaceMetadataCache},
+    util::get_last_write_version,
+};
+use anyhow::Result;
+use foundationdb::Database;
+use hyper::{Body, Response};
+use serde::Deserialize;
+
+const MAX_OWNER_STR_BYTE_SIZE: usize = 256;
+
+#[derive(Deserialize, Copy, Clone)]
+pub enum NslockReleaseMode {
+    #[serde(rename = "commit")]
+    Commit,
+    #[serde(rename = "rollback")]
+    Rollback,
+}
+pub async fn acquire_nslock(
+    db: &Database,
+    key_codec: &KeyCodec,
+    ns_metadata_cache: &NamespaceMetadataCache,
+    ns_id: [u8; 10],
+    owner: &str,
+) -> Result<Response<Body>> {
+    if owner.is_empty() || owner.as_bytes().len() > MAX_OWNER_STR_BYTE_SIZE {
+        return Ok(Response::builder()
+            .status(400)
+            .body(Body::from("invalid owner\n"))?);
+    }
+
+    let mut txn = db.create_trx()?;
+    loop {
+        let metadata = ns_metadata_cache.get(&txn, key_codec, ns_id).await?;
+        let mut metadata = (*metadata).clone();
+
+        // Is this lock already held?
+        if let Some(lock) = &metadata.lock {
+            if lock.owner == owner {
+                return Ok(Response::builder().status(201).body(Body::empty())?);
+            } else {
+                return Ok(Response::builder()
+                    .status(409)
+                    .header("x-lock-owner", &lock.owner)
+                    .body(Body::from("namespace is locked by another owner\n"))?);
+            }
+        }
+
+        let lwv = get_last_write_version(&txn, key_codec, ns_id, false).await?;
+        metadata.lock = Some(NamespaceLock {
+            snapshot_version: hex::encode(&lwv),
+            owner: owner.to_string(),
+            rolling_back: false,
+        });
+        ns_metadata_cache.set(&txn, key_codec, ns_id, Arc::new(metadata))?;
+        match txn.commit().await {
+            Ok(_) => {
+                return Ok(Response::builder().status(201).body(Body::empty())?);
+            }
+            Err(e) => {
+                txn = match e.on_error().await {
+                    Ok(x) => x,
+                    Err(e) => {
+                        return Ok(Response::builder()
+                            .status(400)
+                            .body(Body::from(format!("{}", e)))?)
+                    }
+                };
+            }
+        }
+    }
+}
+
+pub async fn release_nslock(
+    db: &Database,
+    key_codec: &KeyCodec,
+    ns_metadata_cache: &NamespaceMetadataCache,
+    ns_id: [u8; 10],
+    owner: &str,
+    mode: NslockReleaseMode,
+) -> Result<Response<Body>> {
+    if owner.is_empty() {
+        return Ok(Response::builder()
+            .status(400)
+            .body(Body::from("invalid owner\n"))?);
+    }
+
+    let mut txn = db.create_trx()?;
+    loop {
+        let metadata = ns_metadata_cache.get(&txn, key_codec, ns_id).await?;
+        let mut metadata = (*metadata).clone();
+
+        if metadata.lock.is_none() {
+            return Ok(Response::builder()
+                .status(422)
+                .body(Body::from("namespace is not locked"))?);
+        }
+
+        // Can we unlock?
+        let lock = metadata.lock.as_mut().unwrap();
+        if lock.owner != owner {
+            return Ok(Response::builder()
+                .status(422)
+                .header("x-lock-owner", &lock.owner)
+                .body(Body::from("namespace is locked by another owner"))?);
+        }
+
+        match mode {
+            NslockReleaseMode::Commit => {
+                // Commit mode: delete the lock and we're done.
+                metadata.lock = None;
+                ns_metadata_cache.set(&txn, key_codec, ns_id, Arc::new(metadata))?;
+
+                match txn.commit().await {
+                    Ok(_) => {
+                        return Ok(Response::builder().status(201).body(Body::empty())?);
+                    }
+                    Err(e) => {
+                        txn = match e.on_error().await {
+                            Ok(x) => x,
+                            Err(e) => {
+                                return Ok(Response::builder()
+                                    .status(400)
+                                    .body(Body::from(format!("{}", e)))?)
+                            }
+                        };
+                        continue;
+                    }
+                }
+            }
+
+            NslockReleaseMode::Rollback => {
+                // Rollback mode: first mark this lock as being rolled back.
+                if !lock.rolling_back {
+                    lock.rolling_back = true;
+                    ns_metadata_cache.set(&txn, key_codec, ns_id, Arc::new(metadata))?;
+
+                    match txn.commit().await {
+                        Ok(output) => {
+                            txn = output.reset();
+                            break;
+                        }
+                        Err(e) => {
+                            txn = match e.on_error().await {
+                                Ok(x) => x,
+                                Err(e) => {
+                                    return Ok(Response::builder()
+                                        .status(400)
+                                        .body(Body::from(format!("{}", e)))?)
+                                }
+                            };
+                            continue;
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    // We get here when rollback is required
+
+    Ok(Response::builder().status(200).body(Body::empty())?)
+}

--- a/mvstore/src/server.rs
+++ b/mvstore/src/server.rs
@@ -828,7 +828,8 @@ impl Server {
                 let fdb_rv = txn.get_read_version().await;
                 match fdb_rv {
                     Ok(fdb_rv) => {
-                        if fdb_rv < i64::from_be_bytes(<[u8; 8]>::try_from(&version[0..8]).unwrap()) {
+                        // XXX: We are only checking for primary read here due to performance reasons
+                        if !self.is_read_only() && fdb_rv < i64::from_be_bytes(<[u8; 8]>::try_from(&version[0..8]).unwrap()) {
                             Err(anyhow::anyhow!("fdb read version older than requested version - causal read fault?"))
                         } else {
                             Ok(fdb_rv)

--- a/mvstore/src/server.rs
+++ b/mvstore/src/server.rs
@@ -100,6 +100,9 @@ pub struct CommitGlobalInit<'a> {
     pub allow_skip_idempotency_check: bool,
 
     pub num_namespaces: usize,
+
+    #[serde(default)]
+    pub lock_owner: Option<&'a str>,
 }
 
 #[derive(Deserialize)]
@@ -1186,6 +1189,7 @@ impl Server {
                         allow_skip_idempotency_check: commit_global_init
                             .allow_skip_idempotency_check,
                         namespaces: &ns_contexts,
+                        lock_owner: commit_global_init.lock_owner,
                     })
                     .await?
                 {

--- a/mvstore/src/stat.rs
+++ b/mvstore/src/stat.rs
@@ -60,6 +60,10 @@ impl Server {
                     return Err(GoneError("rolling back").into());
                 }
             }
+        } else {
+            if !lock_owner.is_empty() {
+                return Err(GoneError("you do not own the lock").into());
+            }
         }
 
         // If not locked or the client is the lock owner, return LWV

--- a/mvstore/src/stat.rs
+++ b/mvstore/src/stat.rs
@@ -1,13 +1,10 @@
 use std::{
     collections::BTreeSet,
-    sync::{
-        atomic::{AtomicUsize, Ordering},
-        Arc,
-    },
+    sync::atomic::{AtomicUsize, Ordering},
 };
 
-use crate::server::Server;
 use crate::util::decode_version;
+use crate::{server::Server, util::GoneError};
 use anyhow::Result;
 use foundationdb::{
     options::{StreamingMode, TransactionOption},
@@ -32,6 +29,7 @@ impl Server {
         ns_id: [u8; 10],
         from_version: &str,
         crr: bool,
+        lock_owner: &str,
     ) -> Result<StatResponse> {
         let txn = self.db.create_trx()?;
         if self.is_read_only() {
@@ -43,23 +41,46 @@ impl Server {
         }
 
         let rv = txn.get_read_version().await?;
-        let version = self
-            .read_version_and_nsid_to_lwv_cache
-            .try_get_with((rv, ns_id), async {
-                let mut version = [0u8; 10];
-                let last_write_version_key = self.key_codec.construct_last_write_version_key(ns_id);
-                if let Some(t) = txn
-                    .get(&last_write_version_key, false)
-                    .await
-                    .map_err(Arc::new)?
-                {
-                    if t.len() == 16 + 10 {
-                        version = <[u8; 10]>::try_from(&t[16..26]).unwrap();
-                    }
-                }
-                Ok::<[u8; 10], Arc<FdbError>>(version)
-            })
+        let metadata = self
+            .ns_metadata_cache
+            .get(&txn, &self.key_codec, ns_id)
             .await?;
+        let mut version: Option<[u8; 10]> = None;
+
+        if let Some(lock) = &metadata.lock {
+            if lock_owner.is_empty() {
+                // Concurrent read-only transaction, return the latest snapshot
+                version = Some(decode_version(&lock.snapshot_version)?);
+            } else {
+                // Validate lock ownership and state
+                if lock.owner.as_str() != lock_owner {
+                    return Err(GoneError("you no longer own the lock").into());
+                }
+                if lock.rolling_back {
+                    return Err(GoneError("rolling back").into());
+                }
+            }
+        }
+
+        // If not locked or the client is the lock owner, return LWV
+        let version = match version {
+            Some(x) => x,
+            None => {
+                self.read_version_and_nsid_to_lwv_cache
+                    .try_get_with((rv, ns_id), async {
+                        let mut version = [0u8; 10];
+                        let last_write_version_key =
+                            self.key_codec.construct_last_write_version_key(ns_id);
+                        if let Some(t) = txn.get(&last_write_version_key, true).await? {
+                            if t.len() == 16 + 10 {
+                                version = <[u8; 10]>::try_from(&t[16..26]).unwrap();
+                            }
+                        }
+                        Ok::<[u8; 10], FdbError>(version)
+                    })
+                    .await?
+            }
+        };
 
         let mut interval: Option<Vec<u32>> = None;
         if !from_version.is_empty() {

--- a/mvstore/src/util.rs
+++ b/mvstore/src/util.rs
@@ -2,6 +2,7 @@ use std::time::Duration;
 
 use anyhow::{Context, Result};
 use foundationdb::Transaction;
+use thiserror::Error;
 
 pub async fn get_txn_read_version_as_versionstamp(txn: &Transaction) -> Result<[u8; 10]> {
     let read_version = txn.get_read_version().await? as u64;
@@ -49,3 +50,7 @@ impl ContentIndex {
         Ok(Self { time, versionstamp })
     }
 }
+
+#[derive(Error, Debug)]
+#[error("gone: {0}")]
+pub struct GoneError(pub &'static str);

--- a/mvstore/src/util.rs
+++ b/mvstore/src/util.rs
@@ -85,3 +85,18 @@ pub async fn get_last_write_version(
 
     Ok(version)
 }
+
+pub fn truncate_10_byte_suffix(data: &[u8]) -> &[u8] {
+    assert!(data.len() >= 10);
+    &data[..data.len() - 10]
+}
+
+pub fn extract_10_byte_suffix(data: &[u8]) -> [u8; 10] {
+    assert!(data.len() >= 10);
+    <[u8; 10]>::try_from(&data[data.len() - 10..]).unwrap()
+}
+
+pub fn extract_beu32_suffix(data: &[u8]) -> u32 {
+    assert!(data.len() >= 4);
+    u32::from_be_bytes(<[u8; 4]>::try_from(&data[data.len() - 4..]).unwrap())
+}


### PR DESCRIPTION
Related: https://github.com/losfair/mvsqlite/issues/70

This PR implements a restricted form of online DDL. It permits **concurrent read-only DML** when a schema migration task is in progress.

Currently you can already do non-blocking DDL with regular transactions, but that has a few limitations:

- Schema migrations in a large database usually take a long time, and are likely to be indefinitely starved by concurrent small transactions in a busy system.
- A transaction can write at most 50,000 pages of data. This forces the application developer to split a schema migration into multiple smaller transactions, and the application may see inconsistent data in between.

This PR introduces single-writer lock, which when enabled permits only a single writer, the schema migration task, to write to the database. All other tasks see the latest consistent snapshot before the lock.

