### PR TITLE
Database name mapping

### DIFF
--- a/mvfs/src/vfs.rs
+++ b/mvfs/src/vfs.rs
@@ -29,10 +29,17 @@ pub struct MultiVersionVfs {
     pub data_plane: String,
     pub sector_size: usize,
     pub http_client: reqwest::Client,
+    pub db_name_map: Arc<HashMap<String, String>>,
 }
 
 impl MultiVersionVfs {
-    pub fn open(&self, db: &str) -> Result<Connection> {
+    pub fn open(&self, db: &str, map_name: bool) -> Result<Connection> {
+        if map_name {
+            if let Some(mapped) = self.db_name_map.get(db) {
+                return self.open(mapped, false);
+            }
+        }
+
         let (dp, db) = if db.starts_with("http://") || db.starts_with("https://") {
             let url = Url::parse(db)?;
             let dp = Url::parse(&url.origin().ascii_serialization())?;

--- a/mvsqlite-fuse/src/main.rs
+++ b/mvsqlite-fuse/src/main.rs
@@ -95,6 +95,7 @@ async fn main() -> Result<()> {
         data_plane: opt.data_plane.clone(),
         sector_size: opt.sector_size,
         http_client: reqwest::Client::new(),
+        db_name_map: Arc::new(Default::default()),
     };
     let fuse_fs = FuseFs {
         namespaces,
@@ -372,7 +373,7 @@ impl fuser::Filesystem for FuseFs {
                 .unwrap()
                 .remove(&ino);
             let (ns_name, namespace) = self.namespaces.get_index(inode.ns).unwrap();
-            let conn = match self.vfs.open(namespace) {
+            let conn = match self.vfs.open(namespace, false) {
                 Ok(conn) => conn,
                 Err(e) => {
                     tracing::error!(ns = ns_name, error = %e, "failed to open namespace");

--- a/mvsqlite/src/vfs.rs
+++ b/mvsqlite/src/vfs.rs
@@ -27,7 +27,7 @@ impl Vfs for MultiVersionVfs {
 
         let conn = self
             .inner
-            .open(db)
+            .open(db, true)
             .map_err(|e| std::io::Error::new(ErrorKind::Other, e))?;
         Ok(Box::new(Connection {
             io: self.io.clone(),


### PR DESCRIPTION
This implements database aliases. Some applications don't like our special database path formats so let's make them happy.

```
export MVSQLITE_DB_NAME_MAP="/some/path/expected/by/app.db=my-mvsqlite-database"
```
