### PR TITLE
In-memory content cache (mvstore)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -416,6 +416,7 @@ jobs:
     strategy:
       matrix:
         workload: [workloada, workloadb, workloadc]
+        content_cache_size: ["0", "10000"]
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -442,7 +443,8 @@ jobs:
           set -e
           chmod +x ./build/mvstore
           chmod +x ./go-ycsb/go-ycsb
-          RUST_LOG=error ./build/mvstore --data-plane 127.0.0.1:7000 --admin-api 127.0.0.1:7001 --metadata-prefix mvstore-test --raw-data-prefix m &
+          RUST_LOG=error ./build/mvstore --data-plane 127.0.0.1:7000 --admin-api 127.0.0.1:7001 --metadata-prefix mvstore-test --raw-data-prefix m \
+            --content-cache-size "${{ matrix.content_cache_size }}" &
           sleep 1
 
           # Preload mode

--- a/mvstore/src/commit.rs
+++ b/mvstore/src/commit.rs
@@ -118,6 +118,7 @@ impl Server {
                     ns_id: ns.ns_id,
                     key_codec: &self.key_codec,
                     now,
+                    content_cache: self.content_cache.as_ref(),
                 });
                 let res = applier.apply_write(&ns.page_writes).await;
                 match res {
@@ -259,6 +260,7 @@ impl Server {
                     key_codec: &self.key_codec,
                     ns_id: ns.ns_id,
                     replica_manager: None,
+                    content_cache: self.content_cache.as_ref(),
                 };
                 let mut fut_list = FuturesOrdered::new();
                 for &page in &ns.read_set {

--- a/mvstore/src/delta/writer.rs
+++ b/mvstore/src/delta/writer.rs
@@ -1,4 +1,6 @@
+use bytes::Bytes;
 use foundationdb::Transaction;
+use moka::future::Cache;
 
 use crate::{
     delta::reader::DeltaReader, keys::KeyCodec, page::PAGE_ENCODING_DELTA,
@@ -10,6 +12,7 @@ pub struct DeltaWriter<'a> {
     pub txn: &'a Transaction,
     pub ns_id: [u8; 10],
     pub key_codec: &'a KeyCodec,
+    pub content_cache: Option<&'a Cache<[u8; 32], Bytes>>,
 }
 
 impl<'a> DeltaWriter<'a> {
@@ -23,6 +26,7 @@ impl<'a> DeltaWriter<'a> {
             ns_id: self.ns_id,
             key_codec: self.key_codec,
             replica_manager: None,
+            content_cache: self.content_cache,
         };
         let version_hex = hex::encode(&get_txn_read_version_as_versionstamp(self.txn).await?);
 


### PR DESCRIPTION
Normally `mvstore` isn't designed to cache anything. Both FoundationDB and mvsqlite client cache data, so there doesn't need to be another layer.

However some client apps, like [Fossil](https://fossil-scm.org/), work in a way that isn't compatible with client-side caching. They `fork()` on each HTTP request, so the cache cannot be reused.

Let's see whether we can improve performance for such apps by caching content pages in `mvstore`.