### PR TITLE
feat: auto namespace creation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,6 +120,34 @@ jobs:
           sleep 1
           curl http://localhost:7001/api/create_namespace -d '{"key":"stress","metadata":""}'
           RUST_LOG=error,mvstore_stress=info ./build/mvstore-stress --concurrency 50 --data-plane http://localhost:7000 --admin-api http://localhost:7001 --iterations 1000 --ns-key stress --pages 1000
+  stress-auto-create-namespace:
+    name: mvstore stress test
+    runs-on: ubuntu-20.04
+    needs:
+    - build
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Install system dependencies
+        run: |
+          set -e
+          curl -L https://github.com/apple/foundationdb/releases/download/7.1.17/foundationdb-clients_7.1.17-1_amd64.deb --output fdb-client.deb
+          sudo dpkg -i fdb-client.deb
+          curl -L https://github.com/apple/foundationdb/releases/download/7.1.17/foundationdb-server_7.1.17-1_amd64.deb --output fdb-server.deb
+          sudo dpkg -i fdb-server.deb
+      - name: Fetch binaries
+        uses: actions/download-artifact@v3
+        with:
+          name: build
+          path: ./build
+      - name: Run it
+        run: |
+          set -e
+          chmod +x ./build/mvstore ./build/mvstore-stress
+          export RUST_LOG=info
+          ./build/mvstore --data-plane 127.0.0.1:7000 --admin-api 127.0.0.1:7001 --metadata-prefix mvstore-test --raw-data-prefix m --auto-create-namespace &
+          sleep 1
+          RUST_LOG=error,mvstore_stress=info ./build/mvstore-stress --concurrency 50 --data-plane http://localhost:7000 --admin-api http://localhost:7001 --iterations 1000 --ns-key stress --pages 1000
   stress-disable-read-set:
     name: mvstore stress test (disable read set)
     runs-on: ubuntu-20.04

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ RUST_LOG=info ./mvstore \
   --raw-data-prefix m
 ```
 
-You can autocreate namespaces by passing the flag `--auto-create-namespace` to `mvstore` or manually reate a namespace with the admin API:
+You can autocreate namespaces by passing the flag `--auto-create-namespace` to `mvstore` or manually create a namespace with the admin API:
 
 ```bash
 curl http://localhost:7001/api/create_namespace -i -d '{"key":"test"}'

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ RUST_LOG=info ./mvstore \
   --raw-data-prefix m
 ```
 
-Create a namespace with the admin API:
+You can autocreate namespaces by passing the flag `--auto-create-namespace` to `mvstore` or manually reate a namespace with the admin API:
 
 ```bash
 curl http://localhost:7001/api/create_namespace -i -d '{"key":"test"}'

--- a/mvstore/src/main.rs
+++ b/mvstore/src/main.rs
@@ -96,6 +96,11 @@ struct Opt {
     #[structopt(long, env = "MVSTORE_METADATA_PREFIX")]
     metadata_prefix: String,
 
+
+    /// Auto create namespace on request
+    #[structopt(long)]
+    auto_create_namespace: bool,
+
     /// Content cache size in number of pages.
     #[structopt(long, env = "MVSTORE_CONTENT_CACHE_SIZE", default_value = "0")]
     content_cache_size: usize,
@@ -178,6 +183,7 @@ async fn async_main(opt: Opt) -> Result<()> {
         read_only: opt.read_only,
         dr_tag: opt.dr_tag,
         content_cache_size: opt.content_cache_size,
+        auto_create_ns: opt.auto_create_namespace,
     })
     .await
     .with_context(|| "failed to initialize server")?;

--- a/mvstore/src/main.rs
+++ b/mvstore/src/main.rs
@@ -96,7 +96,6 @@ struct Opt {
     #[structopt(long, env = "MVSTORE_METADATA_PREFIX")]
     metadata_prefix: String,
 
-
     /// Auto create namespace on request
     #[structopt(long)]
     auto_create_namespace: bool,

--- a/mvstore/src/server.rs
+++ b/mvstore/src/server.rs
@@ -59,7 +59,6 @@ enum GetError {
     Other(anyhow::Error),
 }
 
-
 #[derive(Debug)]
 enum CreateNamespaceState {
     AlreadyExist,
@@ -72,7 +71,6 @@ impl std::fmt::Display for CreateNamespaceState {
 }
 
 impl std::error::Error for CreateNamespaceState {}
-
 
 pub struct Server {
     pub db: Database,
@@ -333,23 +331,21 @@ impl Server {
                 match self.create_namespace(&body.key, body.overlay_base).await {
                     Ok(_) => {
                         return Ok(Response::builder()
-                                  .status(201)
-                                  .body(Body::from("created\n"))?);
+                            .status(201)
+                            .body(Body::from("created\n"))?);
                     }
-                    Err(e) => {
-                        match e.downcast_ref() {
-                            Some(CreateNamespaceState::AlreadyExist) => {
-                                return Ok(Response::builder()
-                                          .status(422)
-                                          .body(Body::from("this key already exists\n"))?);
-                            },
-                            _ => {
-                                return Ok(Response::builder()
-                                          .status(400)
-                                          .body(Body::from(format!("{}", e)))?);
-                            }
+                    Err(e) => match e.downcast_ref() {
+                        Some(CreateNamespaceState::AlreadyExist) => {
+                            return Ok(Response::builder()
+                                .status(422)
+                                .body(Body::from("this key already exists\n"))?);
                         }
-                    }
+                        _ => {
+                            return Ok(Response::builder()
+                                .status(400)
+                                .body(Body::from(format!("{}", e)))?);
+                        }
+                    },
                 }
             }
 
@@ -855,7 +851,7 @@ impl Server {
                     } else {
                         return Ok(Response::builder()
                             .status(404)
-                            .body(Body::from("namespace not found"))?)
+                            .body(Body::from("namespace not found"))?);
                     }
                 }
             };
@@ -1148,7 +1144,7 @@ impl Server {
                             } else {
                                 return Ok(Response::builder()
                                     .status(404)
-                                    .body(Body::from("namespace not found"))?)
+                                    .body(Body::from("namespace not found"))?);
                             }
                         }
                     };

--- a/mvstore/src/server.rs
+++ b/mvstore/src/server.rs
@@ -60,17 +60,17 @@ enum GetError {
 }
 
 #[derive(Debug)]
-enum CreateNamespaceState {
+enum CreateNamespaceError {
     AlreadyExist,
 }
 
-impl std::fmt::Display for CreateNamespaceState {
+impl std::fmt::Display for CreateNamespaceError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{:?}", self)
     }
 }
 
-impl std::error::Error for CreateNamespaceState {}
+impl std::error::Error for CreateNamespaceError {}
 
 pub struct Server {
     pub db: Database,
@@ -288,7 +288,7 @@ impl Server {
 
         loop {
             if txn.get(&nskey_key, false).await?.is_some() {
-                return Err(anyhow::Error::new(CreateNamespaceState::AlreadyExist));
+                return Err(anyhow::Error::new(CreateNamespaceError::AlreadyExist));
             }
 
             let nsmd_atomic_op_key = generate_suffix_versionstamp_atomic_op(
@@ -335,7 +335,7 @@ impl Server {
                             .body(Body::from("created\n"))?);
                     }
                     Err(e) => match e.downcast_ref() {
-                        Some(CreateNamespaceState::AlreadyExist) => {
+                        Some(CreateNamespaceError::AlreadyExist) => {
                             return Ok(Response::builder()
                                 .status(422)
                                 .body(Body::from("this key already exists\n"))?);

--- a/mvstore/src/server.rs
+++ b/mvstore/src/server.rs
@@ -1138,14 +1138,9 @@ impl Server {
                     {
                         Some(x) => x,
                         None => {
-                            if self.auto_create_ns {
-                                self.create_namespace(init.ns_key, None).await?;
-                                self.lookup_nskey(init.ns_key, None).await?.unwrap()
-                            } else {
-                                return Ok(Response::builder()
-                                    .status(404)
-                                    .body(Body::from("namespace not found"))?);
-                            }
+                            return Ok(Response::builder()
+                                .status(404)
+                                .body(Body::from("namespace not found"))?);
                         }
                     };
                     let client_assumed_version = decode_version(&init.version)?;

--- a/mvstore/src/time2version.rs
+++ b/mvstore/src/time2version.rs
@@ -3,10 +3,7 @@ use std::time::SystemTime;
 use crate::{keys::KeyCodec, replica::ReplicaManager};
 use anyhow::Result;
 use foundationdb::{
-    future::{FdbValue},
-    options::StreamingMode,
-    tuple::unpack,
-    RangeOption, Transaction,
+    future::FdbValue, options::StreamingMode, tuple::unpack, RangeOption, Transaction,
 };
 use futures::TryStreamExt;
 use serde::Serialize;

--- a/mvstore/src/time2version.rs
+++ b/mvstore/src/time2version.rs
@@ -3,7 +3,10 @@ use std::time::SystemTime;
 use crate::{keys::KeyCodec, replica::ReplicaManager};
 use anyhow::Result;
 use foundationdb::{
-    future::FdbValue, options::StreamingMode, tuple::unpack, RangeOption, Transaction,
+    future::{FdbValue},
+    options::StreamingMode,
+    tuple::unpack,
+    RangeOption, Transaction,
 };
 use futures::TryStreamExt;
 use serde::Serialize;


### PR DESCRIPTION
Implemented a solution for for #109 in `mvstore` so the creation happens at the server side.

I thought about doing it in the `mvsqlite` (client) side but I didnt know how to pass variables there and it looked messy when I thought about it.

The flag for the feature in mvstore is `--auto-create-namespace`, if someone want some clients using this features and others dont, they can run two instances of `mvstore` with different prefixes.

Tried my best to keep it minimal and mostly copy pasted stuff, not a rust expert so let me know if there is something wrong i made.

Also a side question, is there a way to get the `ns_id` with the information in the `create_namespace` function so I dont have to call `lookup_nskey` after `create_namespace`? I tried so hard to know where can I get the `ns_id` from the variables inside `create_namespace` but sadly I coudint without doing a `txn.get` inside `create_namespace` after the commit