### PR TITLE
feat: Add Connection.page_stats to get read/write page counts on a connection

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,4 +1,5 @@
 [workspace]
+resolver = "3"
 members = [
     "mvsqlite",
     "mvsqlite-fuse",

--- a/mvfs/src/vfs.rs
+++ b/mvfs/src/vfs.rs
@@ -723,4 +723,13 @@ impl Connection {
     pub fn current_lock(&self) -> LockKind {
         self.lock
     }
+
+    /// Get page read/write statistics from the current transaction.
+    /// Returns Some((pages_read, pages_written)) if a transaction is active,
+    /// or None if no transaction is currently active.
+    pub fn page_stats(&self) -> Option<(usize, usize)> {
+        self.txn.as_ref().map(|txn| {
+            (txn.read_set_size(), txn.written_pages().len())
+        })
+    }
 }

--- a/mvfs/src/vfs.rs
+++ b/mvfs/src/vfs.rs
@@ -728,8 +728,9 @@ impl Connection {
     /// Returns Some((pages_read, pages_written)) if a transaction is active,
     /// or None if no transaction is currently active.
     pub fn page_stats(&self) -> Option<(usize, usize)> {
-        self.txn.as_ref().map(|txn| {
-            (txn.read_set_size(), txn.written_pages().len())
-        })
+        self.txn.as_ref().map(|txn| (
+            txn.read_set_size(),
+            txn.written_pages().len() + self.write_buffer.len()
+        ))
     }
 }

--- a/mvsqlite/Cargo.toml
+++ b/mvsqlite/Cargo.toml
@@ -33,6 +33,7 @@ mvfs = { path = "../mvfs", version = "0.3.0" }
 default = ["loadext", "syscall", "rustls-tls", "global-init"]
 loadext = []
 syscall = []
+sqlite_test = []
 default-tls = ["reqwest/default-tls"]
 rustls-tls = ["reqwest/rustls-tls"]
 global-init = ["tracing-subscriber"]

--- a/mvsqlite/src/lib.rs
+++ b/mvsqlite/src/lib.rs
@@ -411,7 +411,8 @@ pub unsafe extern "C" fn mvsqlite_autocommit_backoff(db: *mut sqlite_c::sqlite3)
 /// Notes:
 /// - Read tracking is automatically enabled for mvsqlite transactions
 /// - Write counting includes both flushed and pending pages
-/// - Call this after `execute()` completes - stats are captured during commit
+/// - Stats are captured when each transaction ends (both reads and writes)
+/// - SELECTs return (pages_read, 0) while INSERTs/UPDATEs return (pages_read, pages_written)
 /// - Stats persist until the next transaction completes
 /// 
 /// # Arguments
@@ -434,6 +435,7 @@ pub unsafe extern "C" fn mvsqlite_autocommit_backoff(db: *mut sqlite_c::sqlite3)
 /// conn.execute("INSERT INTO users (name) VALUES (?)", ["Alice"])?;
 /// 
 /// let (reads, writes) = unsafe {
+
 ///     mvsqlite::get_page_stats_from_handle(
 ///         conn.handle() as *mut std::os::raw::c_void, 
 ///         "main"
@@ -450,3 +452,4 @@ pub unsafe fn get_page_stats_from_handle(
     conn_guard.page_stats()
         .ok_or("No completed transaction - page statistics not available yet")
 }
+

--- a/mvsqlite/src/lib.rs
+++ b/mvsqlite/src/lib.rs
@@ -408,6 +408,12 @@ pub unsafe extern "C" fn mvsqlite_autocommit_backoff(db: *mut sqlite_c::sqlite3)
 /// This function provides access to page I/O statistics for the current 
 /// transaction on the specified database connection.
 /// 
+/// Notes:
+/// - Read tracking is automatically enabled for mvsqlite transactions
+/// - Write counting includes both flushed and pending pages
+/// - Call this immediately after `execute()` while the transaction is still active
+/// - Stats are reset when a new transaction begins (after commit/rollback)
+/// 
 /// # Arguments
 /// * `db` - Raw SQLite database handle (from rusqlite's Connection::handle())
 /// * `db_name` - Database name (typically "main" for the primary database)

--- a/mvsqlite/src/lib.rs
+++ b/mvsqlite/src/lib.rs
@@ -402,3 +402,45 @@ pub unsafe extern "C" fn mvsqlite_autocommit_backoff(db: *mut sqlite_c::sqlite3)
         tokio::time::sleep(Duration::from_millis(100)).await;
     });
 }
+
+/// Get page read/write statistics from the current transaction.
+/// 
+/// This function provides access to page I/O statistics for the current 
+/// transaction on the specified database connection.
+/// 
+/// # Arguments
+/// * `db` - Raw SQLite database handle (from rusqlite's Connection::handle())
+/// * `db_name` - Database name (typically "main" for the primary database)
+/// 
+/// # Returns
+/// `Ok((pages_read, pages_written))` if a transaction is active and stats are available,
+/// or `Err(msg)` if no transaction is active or stats are unavailable.
+/// 
+/// # Safety
+/// This function is unsafe because it requires a valid SQLite database handle.
+/// The caller must ensure the handle is valid and the database name exists.
+/// 
+/// # Example
+/// ```rust
+/// use mvsqlite;
+/// 
+/// let conn = rusqlite::Connection::open("test.db")?;
+/// conn.execute("INSERT INTO users (name) VALUES (?)", ["Alice"])?;
+/// 
+/// let (reads, writes) = unsafe {
+///     mvsqlite::get_page_stats_from_handle(
+///         conn.handle() as *mut std::os::raw::c_void, 
+///         "main"
+///     ).expect("No transaction active - call this immediately after execute()")
+/// };
+/// println!("Read {} pages, wrote {} pages", reads, writes);
+/// ```
+pub unsafe fn get_page_stats_from_handle(
+    db: *mut std::os::raw::c_void, 
+    db_name: &str
+) -> Result<(usize, usize), &'static str> {
+    let db = db as *mut sqlite_c::sqlite3;
+    let conn_guard = get_conn(db, db_name);
+    conn_guard.page_stats()
+        .ok_or("No active transaction - page statistics not available")
+}

--- a/mvsqlite/src/sqlite_vfs/ffi.rs
+++ b/mvsqlite/src/sqlite_vfs/ffi.rs
@@ -711,6 +711,7 @@ pub struct sqlite3_vfs {
     >,
 }
 
+#[allow(clashing_extern_declarations)]
 extern "C" {
     pub fn sqlite3_vfs_register(
         arg1: *mut sqlite3_vfs,

--- a/mvsqlite/src/vfs.rs
+++ b/mvsqlite/src/vfs.rs
@@ -138,6 +138,15 @@ impl DatabaseHandle for Connection {
     }
 }
 
+impl Connection {
+    /// Get page read/write statistics from the current transaction.
+    /// Returns Some((pages_read, pages_written)) if a transaction is active,
+    /// or None if no transaction is currently active.
+    pub fn page_stats(&self) -> Option<(usize, usize)> {
+        self.inner.page_stats()
+    }
+}
+
 impl<W: WalIndex + 'static> DatabaseHandle for Box<dyn DatabaseHandle<WalIndex = W>> {
     type WalIndex = W;
 


### PR DESCRIPTION
Usage:

```rust
use mvsqlite;

let conn = rusqlite::Connection::open("test.db")?;
conn.execute("INSERT INTO users (name) VALUES (?)", ["Alice"])?;

let (reads, writes) = unsafe {
    mvsqlite::get_page_stats_from_handle(
        conn.handle() as *mut std::os::raw::c_void, 
        "main"
    ).expect("No transaction active - call this immediately after execute()")
};

println!("Read {} pages, wrote {} pages", reads, writes);
```