### PR TITLE
Add end-to-end prefetcher benchmark suite for mvsqlite

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,7 @@ target/
 /sqlite-amalgamation-*/
 /sqlite.zip
 /sqlite3
+/_bench_sqlite_repo/
+/_bench_sqlite_src/
+/prefetch_bench_results.*
+/res/ci/prefetch_workloads

--- a/.gitignore
+++ b/.gitignore
@@ -12,4 +12,5 @@ target/
 /_bench_sqlite_repo/
 /_bench_sqlite_src/
 /prefetch_bench_results.*
+/prefetch_bench_metrics.*
 /res/ci/prefetch_workloads

--- a/mvfs/src/prefetch.rs
+++ b/mvfs/src/prefetch.rs
@@ -1,5 +1,49 @@
 use std::collections::HashSet;
 
+// --- Prediction Source ---
+
+/// Identifies which predictor produced a prediction.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PredictionSource {
+    /// Stride detector (sequential / constant-delta patterns).
+    Stride,
+    /// Markov chain (one-step bigram lookup).
+    Markov,
+    /// Markov chain (multi-hop chaining past the first prediction).
+    MarkovChain,
+    /// Cold-start frequency fallback from ring buffer.
+    Frequency,
+}
+
+/// Snapshot of predictor metrics, returned by `PrefetchPredictor::metrics()`.
+#[derive(Debug, Clone, Default)]
+pub struct PrefetchMetrics {
+    pub predictions_made: u32,
+    pub predictions_hit: u32,
+    pub stride_predictions: u32,
+    pub stride_hits: u32,
+    pub markov_predictions: u32,
+    pub markov_hits: u32,
+    pub markov_chain_predictions: u32,
+    pub markov_chain_hits: u32,
+    pub frequency_predictions: u32,
+    pub frequency_hits: u32,
+    /// Total page reads recorded (calls to `record()`).
+    pub page_reads: u32,
+    /// Total cache misses that triggered prediction (calls to `multi_predict()` with max > 0).
+    pub cache_misses: u32,
+}
+
+impl PrefetchMetrics {
+    pub fn hit_rate(&self) -> f32 {
+        if self.predictions_made == 0 {
+            0.0
+        } else {
+            self.predictions_hit as f32 / self.predictions_made as f32
+        }
+    }
+}
+
 // --- Constants ---
 
 /// Number of buckets in the Markov hash table. Must be a power of 2.
@@ -268,10 +312,27 @@ impl RecentHistory {
 
 // --- Predictor Metrics ---
 
+/// Per-prediction entry tracking page and its source.
+#[derive(Clone, Copy)]
+struct PredictionEntry {
+    page: u32,
+    source: PredictionSource,
+}
+
 struct PredictorMetrics {
     predictions_made: u32,
     predictions_hit: u32,
-    recent_predictions: [u32; PREDICTION_TRACK_SIZE],
+    stride_predictions: u32,
+    stride_hits: u32,
+    markov_predictions: u32,
+    markov_hits: u32,
+    markov_chain_predictions: u32,
+    markov_chain_hits: u32,
+    frequency_predictions: u32,
+    frequency_hits: u32,
+    page_reads: u32,
+    cache_misses: u32,
+    recent_predictions: [PredictionEntry; PREDICTION_TRACK_SIZE],
     recent_predictions_len: usize,
 }
 
@@ -280,7 +341,20 @@ impl Default for PredictorMetrics {
         Self {
             predictions_made: 0,
             predictions_hit: 0,
-            recent_predictions: [0; PREDICTION_TRACK_SIZE],
+            stride_predictions: 0,
+            stride_hits: 0,
+            markov_predictions: 0,
+            markov_hits: 0,
+            markov_chain_predictions: 0,
+            markov_chain_hits: 0,
+            frequency_predictions: 0,
+            frequency_hits: 0,
+            page_reads: 0,
+            cache_misses: 0,
+            recent_predictions: [PredictionEntry {
+                page: 0,
+                source: PredictionSource::Stride,
+            }; PREDICTION_TRACK_SIZE],
             recent_predictions_len: 0,
         }
     }
@@ -289,26 +363,53 @@ impl Default for PredictorMetrics {
 impl PredictorMetrics {
     fn check_hit(&mut self, page: u32) {
         for i in 0..self.recent_predictions_len {
-            if self.recent_predictions[i] == page {
+            if self.recent_predictions[i].page == page {
                 self.predictions_hit += 1;
+                match self.recent_predictions[i].source {
+                    PredictionSource::Stride => self.stride_hits += 1,
+                    PredictionSource::Markov => self.markov_hits += 1,
+                    PredictionSource::MarkovChain => self.markov_chain_hits += 1,
+                    PredictionSource::Frequency => self.frequency_hits += 1,
+                }
                 return;
             }
         }
     }
 
-    fn record_predictions(&mut self, pages: &[u32]) {
-        self.predictions_made += pages.len() as u32;
-        let n = pages.len().min(PREDICTION_TRACK_SIZE);
-        self.recent_predictions[..n].copy_from_slice(&pages[..n]);
+    fn record_predictions(&mut self, entries: &[(u32, PredictionSource)]) {
+        self.predictions_made += entries.len() as u32;
+        for &(_, source) in entries {
+            match source {
+                PredictionSource::Stride => self.stride_predictions += 1,
+                PredictionSource::Markov => self.markov_predictions += 1,
+                PredictionSource::MarkovChain => self.markov_chain_predictions += 1,
+                PredictionSource::Frequency => self.frequency_predictions += 1,
+            }
+        }
+        let n = entries.len().min(PREDICTION_TRACK_SIZE);
+        for i in 0..n {
+            self.recent_predictions[i] = PredictionEntry {
+                page: entries[i].0,
+                source: entries[i].1,
+            };
+        }
         self.recent_predictions_len = n;
     }
 
-    #[allow(dead_code)]
-    fn hit_rate(&self) -> f32 {
-        if self.predictions_made == 0 {
-            0.0
-        } else {
-            self.predictions_hit as f32 / self.predictions_made as f32
+    fn snapshot(&self) -> PrefetchMetrics {
+        PrefetchMetrics {
+            predictions_made: self.predictions_made,
+            predictions_hit: self.predictions_hit,
+            stride_predictions: self.stride_predictions,
+            stride_hits: self.stride_hits,
+            markov_predictions: self.markov_predictions,
+            markov_hits: self.markov_hits,
+            markov_chain_predictions: self.markov_chain_predictions,
+            markov_chain_hits: self.markov_chain_hits,
+            frequency_predictions: self.frequency_predictions,
+            frequency_hits: self.frequency_hits,
+            page_reads: self.page_reads,
+            cache_misses: self.cache_misses,
         }
     }
 }
@@ -334,8 +435,15 @@ impl PrefetchPredictor {
         }
     }
 
+    /// Return a snapshot of the current predictor metrics.
+    pub fn metrics(&self) -> PrefetchMetrics {
+        self.metrics.snapshot()
+    }
+
     /// Record a page access. Called on every page read.
     pub fn record(&mut self, current_page: u32) {
+        self.metrics.page_reads += 1;
+
         // Check if this page was predicted (metrics)
         self.metrics.check_hit(current_page);
 
@@ -380,26 +488,31 @@ impl PrefetchPredictor {
         self.history.invalidate_last_delta();
     }
 
-    /// Predict next pages from the current page. Returns (page, confidence) pairs
+    /// Predict next pages from the current page. Returns (page, confidence, source) triples
     /// sorted by confidence descending, limited to `max_pages` entries.
-    fn predict(&self, current_page: u32, max_pages: usize) -> Vec<(u32, f32)> {
+    fn predict(&self, current_page: u32, max_pages: usize) -> Vec<(u32, f32, PredictionSource)> {
         if max_pages == 0 {
             return Vec::new();
         }
 
         // Cold-start: fall back to frequency counting
         if self.history.len < 4 {
-            let mut preds = self.history.frequency_predict(current_page);
+            let mut preds: Vec<(u32, f32, PredictionSource)> = self
+                .history
+                .frequency_predict(current_page)
+                .into_iter()
+                .map(|(page, conf)| (page, conf, PredictionSource::Frequency))
+                .collect();
             preds.truncate(max_pages);
             return preds;
         }
 
-        let mut predictions: Vec<(u32, f32)> = Vec::new();
+        let mut predictions: Vec<(u32, f32, PredictionSource)> = Vec::new();
 
         // 1. Stride predictions (capped to max_pages)
         let stride_preds = self.stride.predict(current_page, max_pages);
         for (page, conf) in &stride_preds {
-            predictions.push((*page, *conf));
+            predictions.push((*page, *conf, PredictionSource::Stride));
         }
 
         // 2. Markov predictions
@@ -416,8 +529,10 @@ impl PrefetchPredictor {
                                 predictions.iter_mut().find(|p| p.0 == page)
                             {
                                 existing.1 = existing.1.max(prob);
+                                // If both stride and markov predict the same page,
+                                // keep the stride source (it was first).
                             } else {
-                                predictions.push((page, prob));
+                                predictions.push((page, prob, PredictionSource::Markov));
                             }
                         }
                     }
@@ -440,17 +555,24 @@ impl PrefetchPredictor {
     /// Multi-step prediction chaining. Returns a set of predicted page IDs,
     /// containing at most `max_pages` entries.
     pub fn multi_predict(&mut self, current_page: u32, max_pages: usize) -> HashSet<u32> {
+        if max_pages > 0 {
+            self.metrics.cache_misses += 1;
+        }
+
         let mut result: HashSet<u32> = HashSet::with_capacity(max_pages);
+        let mut tagged: Vec<(u32, PredictionSource)> = Vec::with_capacity(max_pages);
 
         // Get initial one-step predictions (already capped)
         let initial = self.predict(current_page, max_pages);
-        for (page, _) in &initial {
-            result.insert(*page);
+        for &(page, _, source) in &initial {
+            if result.insert(page) {
+                tagged.push((page, source));
+            }
         }
 
         // Chain further predictions via Markov, starting from the best
         // one-step prediction so we advance past the first hop.
-        if let Some(&(first_page, _)) = initial.first() {
+        if let Some(&(first_page, _, _)) = initial.first() {
             let mut last_page = first_page;
             // The delta that led to first_page
             let mut last_delta = first_page as i64 - current_page as i64;
@@ -471,6 +593,7 @@ impl PrefetchPredictor {
                     if next_page == current_page || !result.insert(next_page) {
                         break;
                     }
+                    tagged.push((next_page, PredictionSource::MarkovChain));
                     last_page = next_page;
                     last_delta = *next_delta;
                 } else {
@@ -480,8 +603,7 @@ impl PrefetchPredictor {
         }
 
         // Record predictions for metrics
-        let pred_pages: Vec<u32> = result.iter().copied().collect();
-        self.metrics.record_predictions(&pred_pages);
+        self.metrics.record_predictions(&tagged);
 
         result
     }

--- a/mvfs/src/vfs.rs
+++ b/mvfs/src/vfs.rs
@@ -177,6 +177,10 @@ impl Connection {
         self.last_known_write_version.as_deref()
     }
 
+    pub fn prefetch_metrics(&self) -> crate::prefetch::PrefetchMetrics {
+        self.predictor.metrics()
+    }
+
     pub async fn do_read_raw(&mut self, buf: &mut [u8], offset: u64) -> Result<(), std::io::Error> {
         assert!(offset as usize % self.sector_size == 0);
         assert!(buf.len() == self.sector_size);
@@ -724,7 +728,22 @@ impl Connection {
         };
 
         if lock == LockKind::None {
-            // All locks dropped
+            // All locks dropped — log prefetch metrics before resetting.
+            let m = self.predictor.metrics();
+            if m.predictions_made > 0 {
+                tracing::info!(
+                    page_reads = m.page_reads,
+                    cache_misses = m.cache_misses,
+                    predictions = m.predictions_made,
+                    hits = m.predictions_hit,
+                    hit_rate = format_args!("{:.1}%", m.hit_rate() * 100.0),
+                    stride = format_args!("{}/{}", m.stride_hits, m.stride_predictions),
+                    markov = format_args!("{}/{}", m.markov_hits, m.markov_predictions),
+                    markov_chain = format_args!("{}/{}", m.markov_chain_hits, m.markov_chain_predictions),
+                    frequency = format_args!("{}/{}", m.frequency_hits, m.frequency_predictions),
+                    "prefetch metrics"
+                );
+            }
             self.txn = None;
             self.predictor.reset();
         }

--- a/mvsqlite/src/lib.rs
+++ b/mvsqlite/src/lib.rs
@@ -235,6 +235,7 @@ pub unsafe extern "C" fn init_mvsqlite_connection(db: *mut sqlite_c::sqlite3) {
     let mv_time2version_name = b"mv_time2version\0";
     let mv_pin_version_name = b"mv_pin_version\0";
     let mv_unpin_version_name = b"mv_unpin_version\0";
+    let mv_prefetch_metrics_name = b"mv_prefetch_metrics\0";
 
     let ret = sqlite_c::sqlite3_create_function_v2(
         db,
@@ -282,6 +283,19 @@ pub unsafe extern "C" fn init_mvsqlite_connection(db: *mut sqlite_c::sqlite3) {
         sqlite_c::SQLITE_UTF8 | sqlite_c::SQLITE_DIRECTONLY,
         std::ptr::null_mut(),
         Some(mv_unpin_version),
+        None,
+        None,
+        None,
+    );
+    assert_eq!(ret, sqlite_c::SQLITE_OK);
+
+    let ret = sqlite_c::sqlite3_create_function_v2(
+        db,
+        mv_prefetch_metrics_name.as_ptr() as *const c_char,
+        1,
+        sqlite_c::SQLITE_UTF8 | sqlite_c::SQLITE_DIRECTONLY,
+        std::ptr::null_mut(),
+        Some(mv_prefetch_metrics),
         None,
         None,
         None,
@@ -441,6 +455,60 @@ unsafe extern "C" fn mv_unpin_version(
             sqlite_c::sqlite3_result_error(ctx, error.as_ptr(), error.as_bytes().len() as i32);
         }
     }
+}
+
+unsafe extern "C" fn mv_prefetch_metrics(
+    ctx: *mut sqlite_c::sqlite3_context,
+    argc: std::os::raw::c_int,
+    argv: *mut *mut sqlite_c::sqlite3_value,
+) {
+    assert_eq!(argc, 1);
+    let db = sqlite_c::sqlite3_context_db_handle(ctx);
+    let selected_db = sqlite_c::sqlite3_value_text(*argv.add(0));
+    let selected_db = std::ffi::CStr::from_ptr(selected_db as *const c_char)
+        .to_str()
+        .unwrap();
+    let conn = get_conn(db, selected_db);
+    let m = conn.inner.prefetch_metrics();
+    let json = format!(
+        concat!(
+            "{{",
+            "\"page_reads\":{},",
+            "\"cache_misses\":{},",
+            "\"predictions_made\":{},",
+            "\"predictions_hit\":{},",
+            "\"hit_rate\":{:.4},",
+            "\"stride_predictions\":{},",
+            "\"stride_hits\":{},",
+            "\"markov_predictions\":{},",
+            "\"markov_hits\":{},",
+            "\"markov_chain_predictions\":{},",
+            "\"markov_chain_hits\":{},",
+            "\"frequency_predictions\":{},",
+            "\"frequency_hits\":{}",
+            "}}"
+        ),
+        m.page_reads,
+        m.cache_misses,
+        m.predictions_made,
+        m.predictions_hit,
+        m.hit_rate(),
+        m.stride_predictions,
+        m.stride_hits,
+        m.markov_predictions,
+        m.markov_hits,
+        m.markov_chain_predictions,
+        m.markov_chain_hits,
+        m.frequency_predictions,
+        m.frequency_hits,
+    );
+    let json = CString::new(json).unwrap();
+    sqlite_c::sqlite3_result_text(
+        ctx,
+        json.as_ptr(),
+        json.as_bytes().len() as i32,
+        crate::sqlite_misc::SQLITE_TRANSIENT(),
+    );
 }
 
 #[no_mangle]

--- a/res/ci/prefetch_bench.sh
+++ b/res/ci/prefetch_bench.sh
@@ -1,0 +1,404 @@
+#!/bin/bash
+#
+# prefetch_bench.sh - End-to-end prefetcher benchmark for mvsqlite
+#
+# Runs SQLite workloads through the full stack (SQLite -> mvsqlite -> mvstore -> FDB)
+# with varying prefetch depths and reports a comparison table.
+#
+# Prerequisites:
+#   - FoundationDB installed and running
+#   - cargo build --release -p mvstore -p mvsqlite
+#   - make -C mvsqlite-preload build-patched-sqlite3
+#
+# Usage:
+#   bash res/ci/prefetch_bench.sh [--quick]
+#
+# Options:
+#   --quick   Only test depth=0 and depth=8, single cache configuration
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+# ---------- Configuration ----------
+
+QUICK_MODE=0
+if [[ "${1:-}" == "--quick" ]]; then
+    QUICK_MODE=1
+    shift
+fi
+
+if [[ $QUICK_MODE -eq 1 ]]; then
+    PREFETCH_DEPTHS=(0 8)
+    PAGE_CACHE_SIZES=(5000)
+    CONTENT_CACHE_SIZES=(0)
+else
+    PREFETCH_DEPTHS=(0 4 8 16 32)
+    PAGE_CACHE_SIZES=(0 5000)
+    CONTENT_CACHE_SIZES=(0 10000)
+fi
+
+NUM_RUNS=3
+MVSTORE_PORT=7000
+ADMIN_PORT=7001
+MVSTORE_PID=""
+
+WORKLOADS=(seq_scan rev_scan idx_range point_lookup btree_probe mixed_rw repeated_scan)
+
+# Output files
+RESULTS_CSV="$ROOT_DIR/prefetch_bench_results.csv"
+RESULTS_TXT="$ROOT_DIR/prefetch_bench_results.txt"
+
+# ---------- Paths ----------
+
+MVSTORE="$ROOT_DIR/target/release/mvstore"
+PRELOAD_LIB="$ROOT_DIR/mvsqlite-preload/libmvsqlite_preload.so"
+PATCHED_SQLITE="$ROOT_DIR/mvsqlite-preload/libsqlite3.so"
+WORKLOAD_BIN="$ROOT_DIR/res/ci/prefetch_workloads"
+SPEEDTEST1=""  # set during build phase
+
+# ---------- Build / check ----------
+
+check_prerequisites() {
+    local missing=0
+
+    if [[ ! -x "$MVSTORE" ]]; then
+        echo "ERROR: mvstore not found at $MVSTORE"
+        echo "  Run: cargo build --release -p mvstore"
+        missing=1
+    fi
+
+    if [[ ! -f "$ROOT_DIR/target/release/libmvsqlite.a" ]]; then
+        echo "ERROR: libmvsqlite.a not found"
+        echo "  Run: cargo build --release -p mvsqlite"
+        missing=1
+    fi
+
+    if ! command -v fdbcli &>/dev/null; then
+        echo "ERROR: fdbcli not found. Install FoundationDB."
+        missing=1
+    fi
+
+    if [[ $missing -eq 1 ]]; then
+        exit 1
+    fi
+}
+
+build_patched_sqlite() {
+    echo "=== Building patched libsqlite3.so ==="
+
+    local sqlite_dir="$ROOT_DIR/_bench_sqlite_src"
+
+    # Download sqlite3.c if not already in mvsqlite-preload
+    if [[ ! -f "$ROOT_DIR/mvsqlite-preload/sqlite3.c" ]]; then
+        echo "Downloading SQLite amalgamation..."
+        mkdir -p "$sqlite_dir"
+        cd "$sqlite_dir"
+        if [[ ! -f sqlite3.c ]]; then
+            curl -fL -o sqlite.zip https://sqlite.org/2026/sqlite-amalgamation-3510300.zip
+            unzip -o sqlite.zip
+            cp sqlite-amalgamation-3510300/sqlite3.c .
+        fi
+        cp sqlite3.c "$ROOT_DIR/mvsqlite-preload/sqlite3.c"
+        cd "$ROOT_DIR/mvsqlite-preload"
+        patch -p0 sqlite3.c < sqlite-3510300.patch
+    fi
+
+    cd "$ROOT_DIR"
+    make -C mvsqlite-preload build-patched-sqlite3
+    echo "  Built: $PATCHED_SQLITE"
+}
+
+build_workload_binary() {
+    echo "=== Building prefetch_workloads benchmark ==="
+    gcc -O2 -o "$WORKLOAD_BIN" "$ROOT_DIR/res/ci/prefetch_workloads.c" \
+        -I"$ROOT_DIR/mvsqlite-preload" \
+        -L"$ROOT_DIR/mvsqlite-preload" \
+        -Wl,-rpath,"$ROOT_DIR/mvsqlite-preload" \
+        -lsqlite3 -lpthread -ldl -lm
+    echo "  Built: $WORKLOAD_BIN"
+}
+
+build_speedtest1() {
+    echo "=== Building speedtest1 ==="
+
+    local sqlite_src="$ROOT_DIR/_bench_sqlite_repo"
+    if [[ ! -d "$sqlite_src" ]]; then
+        git clone --depth=1 --branch version-3.31.1 https://github.com/sqlite/sqlite "$sqlite_src"
+        cd "$sqlite_src"
+        git apply "$ROOT_DIR/res/ci/sqlite.patch"
+    fi
+
+    cd "$sqlite_src"
+    gcc -O2 -o speedtest1 test/speedtest1.c \
+        -I"$ROOT_DIR/mvsqlite-preload" \
+        -L"$ROOT_DIR/mvsqlite-preload" \
+        -Wl,-rpath,"$ROOT_DIR/mvsqlite-preload" \
+        -lsqlite3 -lpthread -ldl -lm
+
+    SPEEDTEST1="$sqlite_src/speedtest1"
+    echo "  Built: $SPEEDTEST1"
+    cd "$ROOT_DIR"
+}
+
+# ---------- mvstore lifecycle ----------
+
+start_mvstore() {
+    local content_cache_size="$1"
+    echo "--- Starting mvstore (content_cache=$content_cache_size) ---"
+
+    RUST_LOG=error "$MVSTORE" \
+        --data-plane "127.0.0.1:$MVSTORE_PORT" \
+        --admin-api "127.0.0.1:$ADMIN_PORT" \
+        --metadata-prefix mvstore-bench \
+        --raw-data-prefix b \
+        --auto-create-namespace \
+        --content-cache-size "$content_cache_size" &
+    MVSTORE_PID=$!
+    sleep 2
+
+    if ! kill -0 "$MVSTORE_PID" 2>/dev/null; then
+        echo "ERROR: mvstore failed to start"
+        exit 1
+    fi
+}
+
+stop_mvstore() {
+    if [[ -n "$MVSTORE_PID" ]] && kill -0 "$MVSTORE_PID" 2>/dev/null; then
+        echo "--- Stopping mvstore (PID $MVSTORE_PID) ---"
+        kill "$MVSTORE_PID" || true
+        wait "$MVSTORE_PID" 2>/dev/null || true
+        MVSTORE_PID=""
+        sleep 1
+    fi
+}
+
+create_namespace() {
+    local ns="$1"
+    curl -sf "http://localhost:$ADMIN_PORT/api/create_namespace" \
+        -d "{\"key\":\"$ns\",\"metadata\":\"\"}" >/dev/null 2>&1 || true
+}
+
+# ---------- Benchmark runners ----------
+
+# Run speedtest1, return the TOTAL time in seconds
+run_speedtest1() {
+    local ns="$1"
+    local depth="$2"
+    local page_cache="$3"
+
+    create_namespace "$ns"
+
+    local output
+    output=$(LD_LIBRARY_PATH="$ROOT_DIR/mvsqlite-preload" \
+        MVSQLITE_DATA_PLANE="http://localhost:$MVSTORE_PORT" \
+        MVSQLITE_PREFETCH_DEPTH="$depth" \
+        MVSQLITE_PAGE_CACHE_SIZE="$page_cache" \
+        RUST_LOG=error \
+        "$SPEEDTEST1" "$ns" 2>&1) || true
+
+    # Parse TOTAL line: "     TOTAL                                          1.234s"
+    local total
+    total=$(echo "$output" | grep -oP 'TOTAL\s+\K[0-9.]+(?=s)' || echo "0")
+    echo "$total"
+}
+
+# Run custom workloads, output RESULT lines
+run_custom_workloads() {
+    local ns="$1"
+    local depth="$2"
+    local page_cache="$3"
+
+    create_namespace "$ns"
+
+    # Setup phase (always with depth=0 for fairness)
+    LD_LIBRARY_PATH="$ROOT_DIR/mvsqlite-preload" \
+        MVSQLITE_DATA_PLANE="http://localhost:$MVSTORE_PORT" \
+        MVSQLITE_PREFETCH_DEPTH=0 \
+        MVSQLITE_PAGE_CACHE_SIZE="$page_cache" \
+        RUST_LOG=error \
+        "$WORKLOAD_BIN" "$ns" setup all 2>&1 | sed 's/^/  [setup] /' >&2
+
+    # Run phase with configured depth
+    LD_LIBRARY_PATH="$ROOT_DIR/mvsqlite-preload" \
+        MVSQLITE_DATA_PLANE="http://localhost:$MVSTORE_PORT" \
+        MVSQLITE_PREFETCH_DEPTH="$depth" \
+        MVSQLITE_PAGE_CACHE_SIZE="$page_cache" \
+        RUST_LOG=error \
+        "$WORKLOAD_BIN" "$ns" run all "$NUM_RUNS" 2>/dev/null
+}
+
+# ---------- Result collection ----------
+
+declare -A RESULTS  # key: "cc:pc:depth:workload" -> value: seconds
+
+collect_result() {
+    local cc="$1" pc="$2" depth="$3" workload="$4" secs="$5"
+    RESULTS["$cc:$pc:$depth:$workload"]="$secs"
+    echo "$cc,$pc,$depth,$workload,$secs" >> "$RESULTS_CSV"
+}
+
+# ---------- Report generation ----------
+
+print_table() {
+    local cc="$1" pc="$2"
+
+    echo ""
+    echo "=== Content cache: $cc, Page cache: $pc ==="
+    echo ""
+
+    # Header
+    printf "%-20s" "Workload"
+    for depth in "${PREFETCH_DEPTHS[@]}"; do
+        printf "%12s" "depth=$depth"
+    done
+    echo ""
+    printf '%0.s-' {1..80}; echo ""
+
+    # speedtest1 row
+    printf "%-20s" "speedtest1"
+    for depth in "${PREFETCH_DEPTHS[@]}"; do
+        local val="${RESULTS[$cc:$pc:$depth:speedtest1]:-N/A}"
+        if [[ "$val" != "N/A" ]]; then
+            printf "%11.3fs" "$val"
+        else
+            printf "%12s" "N/A"
+        fi
+    done
+    echo ""
+
+    # Custom workload rows
+    for wl in "${WORKLOADS[@]}"; do
+        printf "%-20s" "$wl"
+        for depth in "${PREFETCH_DEPTHS[@]}"; do
+            local val="${RESULTS[$cc:$pc:$depth:$wl]:-N/A}"
+            if [[ "$val" != "N/A" ]]; then
+                printf "%11.6fs" "$val"
+            else
+                printf "%12s" "N/A"
+            fi
+        done
+        echo ""
+    done
+
+    # Speedup table
+    echo ""
+    printf "%-20s" "Speedup vs depth=0"
+    for depth in "${PREFETCH_DEPTHS[@]}"; do
+        printf "%12s" "depth=$depth"
+    done
+    echo ""
+    printf '%0.s-' {1..80}; echo ""
+
+    local all_wl=("speedtest1" "${WORKLOADS[@]}")
+    for wl in "${all_wl[@]}"; do
+        printf "%-20s" "$wl"
+        local base="${RESULTS[$cc:$pc:0:$wl]:-0}"
+        for depth in "${PREFETCH_DEPTHS[@]}"; do
+            local val="${RESULTS[$cc:$pc:$depth:$wl]:-0}"
+            if [[ "$base" != "0" ]] && [[ "$val" != "0" ]] && [[ "$base" != "N/A" ]] && [[ "$val" != "N/A" ]]; then
+                local speedup
+                speedup=$(awk "BEGIN { printf \"%.2f\", $base / $val }")
+                printf "%11sx" "$speedup"
+            else
+                printf "%12s" "N/A"
+            fi
+        done
+        echo ""
+    done
+}
+
+# ---------- Cleanup ----------
+
+cleanup() {
+    stop_mvstore
+    echo "Benchmark complete."
+}
+trap cleanup EXIT
+
+# ================================================================
+# Main
+# ================================================================
+
+echo "========================================"
+echo " mvsqlite Prefetcher Benchmark"
+echo "========================================"
+echo ""
+echo "Configuration:"
+echo "  Prefetch depths: ${PREFETCH_DEPTHS[*]}"
+echo "  Page cache sizes: ${PAGE_CACHE_SIZES[*]}"
+echo "  Content cache sizes: ${CONTENT_CACHE_SIZES[*]}"
+echo "  Iterations per workload: $NUM_RUNS"
+echo ""
+
+check_prerequisites
+
+# Build phase
+build_patched_sqlite
+build_workload_binary
+build_speedtest1
+
+# Initialize CSV
+echo "content_cache,page_cache,prefetch_depth,workload,seconds" > "$RESULTS_CSV"
+
+# Run benchmark matrix
+for cc in "${CONTENT_CACHE_SIZES[@]}"; do
+    start_mvstore "$cc"
+
+    for pc in "${PAGE_CACHE_SIZES[@]}"; do
+        echo ""
+        echo "========================================"
+        echo " Testing: content_cache=$cc, page_cache=$pc"
+        echo "========================================"
+
+        for depth in "${PREFETCH_DEPTHS[@]}"; do
+            echo ""
+            echo "--- depth=$depth ---"
+
+            # speedtest1
+            local_ns="st1-cc${cc}-pc${pc}-d${depth}"
+            echo "Running speedtest1 (ns=$local_ns)..."
+            st1_time=$(run_speedtest1 "$local_ns" "$depth" "$pc")
+            echo "  speedtest1 TOTAL: ${st1_time}s"
+            collect_result "$cc" "$pc" "$depth" "speedtest1" "$st1_time"
+
+            # Custom workloads
+            local_ns="wl-cc${cc}-pc${pc}-d${depth}"
+            echo "Running custom workloads (ns=$local_ns)..."
+            while IFS= read -r line; do
+                if [[ "$line" == RESULT* ]]; then
+                    # Parse: RESULT <name> <median> <min> <max>
+                    wl_name=$(echo "$line" | awk '{print $2}')
+                    wl_median=$(echo "$line" | awk '{print $3}')
+                    echo "  $wl_name: ${wl_median}s"
+                    collect_result "$cc" "$pc" "$depth" "$wl_name" "$wl_median"
+                fi
+            done < <(run_custom_workloads "$local_ns" "$depth" "$pc")
+        done
+    done
+
+    stop_mvstore
+done
+
+# Print results
+{
+    echo ""
+    echo "========================================"
+    echo " RESULTS"
+    echo "========================================"
+
+    for cc in "${CONTENT_CACHE_SIZES[@]}"; do
+        for pc in "${PAGE_CACHE_SIZES[@]}"; do
+            print_table "$cc" "$pc"
+        done
+    done
+
+    echo ""
+    echo "Raw CSV: $RESULTS_CSV"
+} | tee "$RESULTS_TXT"
+
+echo ""
+echo "Results saved to:"
+echo "  CSV: $RESULTS_CSV"
+echo "  Text: $RESULTS_TXT"

--- a/res/ci/prefetch_bench.sh
+++ b/res/ci/prefetch_bench.sh
@@ -52,6 +52,7 @@ WORKLOADS=(seq_scan rev_scan idx_range point_lookup btree_probe mixed_rw repeate
 
 # Output files
 RESULTS_CSV="$ROOT_DIR/prefetch_bench_results.csv"
+METRICS_CSV="$ROOT_DIR/prefetch_bench_metrics.csv"
 RESULTS_TXT="$ROOT_DIR/prefetch_bench_results.txt"
 
 # ---------- Paths ----------
@@ -242,12 +243,19 @@ run_custom_workloads() {
 
 # ---------- Result collection ----------
 
-declare -A RESULTS  # key: "cc:pc:depth:workload" -> value: seconds
+declare -A RESULTS   # key: "cc:pc:depth:workload" -> value: seconds
+declare -A METRICS   # key: "cc:pc:depth:workload" -> value: JSON string
 
 collect_result() {
     local cc="$1" pc="$2" depth="$3" workload="$4" secs="$5"
     RESULTS["$cc:$pc:$depth:$workload"]="$secs"
     echo "$cc,$pc,$depth,$workload,$secs" >> "$RESULTS_CSV"
+}
+
+collect_metrics() {
+    local cc="$1" pc="$2" depth="$3" workload="$4" json="$5"
+    METRICS["$cc:$pc:$depth:$workload"]="$json"
+    echo "$cc,$pc,$depth,$workload,$json" >> "$METRICS_CSV"
 }
 
 # ---------- Report generation ----------
@@ -320,6 +328,47 @@ print_table() {
     done
 }
 
+print_metrics_table() {
+    local cc="$1" pc="$2"
+
+    echo ""
+    echo "=== Prefetch Metrics: Content cache: $cc, Page cache: $pc ==="
+    echo ""
+    printf "%-20s %6s %10s %10s %9s | %12s %12s %12s %12s\n" \
+        "Workload" "Depth" "Reads" "Misses" "Hit%" \
+        "Stride" "Markov" "Chain" "Freq"
+    printf '%0.s-' {1..120}; echo ""
+
+    for wl in "${WORKLOADS[@]}"; do
+        for depth in "${PREFETCH_DEPTHS[@]}"; do
+            local json="${METRICS[$cc:$pc:$depth:$wl]:-}"
+            if [[ -z "$json" ]]; then
+                continue
+            fi
+            # Extract fields from JSON using grep/sed (no jq dependency)
+            local reads=$(echo "$json" | grep -oP '"page_reads":\K[0-9]+')
+            local misses=$(echo "$json" | grep -oP '"cache_misses":\K[0-9]+')
+            local preds=$(echo "$json" | grep -oP '"predictions_made":\K[0-9]+')
+            local hits=$(echo "$json" | grep -oP '"predictions_hit":\K[0-9]+')
+            local hit_rate=$(echo "$json" | grep -oP '"hit_rate":\K[0-9.]+')
+            local s_pred=$(echo "$json" | grep -oP '"stride_predictions":\K[0-9]+')
+            local s_hit=$(echo "$json" | grep -oP '"stride_hits":\K[0-9]+')
+            local m_pred=$(echo "$json" | grep -oP '"markov_predictions":\K[0-9]+')
+            local m_hit=$(echo "$json" | grep -oP '"markov_hits":\K[0-9]+')
+            local mc_pred=$(echo "$json" | grep -oP '"markov_chain_predictions":\K[0-9]+')
+            local mc_hit=$(echo "$json" | grep -oP '"markov_chain_hits":\K[0-9]+')
+            local f_pred=$(echo "$json" | grep -oP '"frequency_predictions":\K[0-9]+')
+            local f_hit=$(echo "$json" | grep -oP '"frequency_hits":\K[0-9]+')
+            local hit_pct
+            hit_pct=$(awk "BEGIN { printf \"%.1f\", $hit_rate * 100 }")
+
+            printf "%-20s %6d %10s %10s %8s%% | %5s/%-6s %5s/%-6s %5s/%-6s %5s/%-6s\n" \
+                "$wl" "$depth" "$reads" "$misses" "$hit_pct" \
+                "$s_hit" "$s_pred" "$m_hit" "$m_pred" "$mc_hit" "$mc_pred" "$f_hit" "$f_pred"
+        done
+    done
+}
+
 # ---------- Cleanup ----------
 
 cleanup() {
@@ -350,8 +399,9 @@ build_patched_sqlite
 build_workload_binary
 build_speedtest1
 
-# Initialize CSV
+# Initialize CSV files
 echo "content_cache,page_cache,prefetch_depth,workload,seconds" > "$RESULTS_CSV"
+echo "content_cache,page_cache,prefetch_depth,workload,metrics_json" > "$METRICS_CSV"
 
 # Run benchmark matrix
 for cc in "${CONTENT_CACHE_SIZES[@]}"; do
@@ -384,6 +434,11 @@ for cc in "${CONTENT_CACHE_SIZES[@]}"; do
                     wl_median=$(echo "$line" | awk '{print $3}')
                     echo "  $wl_name: ${wl_median}s"
                     collect_result "$cc" "$pc" "$depth" "$wl_name" "$wl_median"
+                elif [[ "$line" == METRICS* ]]; then
+                    # Parse: METRICS <name> <json>
+                    wl_name=$(echo "$line" | awk '{print $2}')
+                    wl_json=$(echo "$line" | cut -d' ' -f3-)
+                    collect_metrics "$cc" "$pc" "$depth" "$wl_name" "$wl_json"
                 fi
             done < <(run_custom_workloads "$local_ns" "$depth" "$pc")
         done
@@ -402,14 +457,17 @@ done
     for cc in "${CONTENT_CACHE_SIZES[@]}"; do
         for pc in "${PAGE_CACHE_SIZES[@]}"; do
             print_table "$cc" "$pc"
+            print_metrics_table "$cc" "$pc"
         done
     done
 
     echo ""
     echo "Raw CSV: $RESULTS_CSV"
+    echo "Metrics CSV: $METRICS_CSV"
 } | tee "$RESULTS_TXT"
 
 echo ""
 echo "Results saved to:"
 echo "  CSV: $RESULTS_CSV"
+echo "  Metrics: $METRICS_CSV"
 echo "  Text: $RESULTS_TXT"

--- a/res/ci/prefetch_bench.sh
+++ b/res/ci/prefetch_bench.sh
@@ -39,7 +39,11 @@ else
     CONTENT_CACHE_SIZES=(0 10000)
 fi
 
-NUM_RUNS=3
+if [[ $QUICK_MODE -eq 1 ]]; then
+    NUM_RUNS=1
+else
+    NUM_RUNS=3
+fi
 MVSTORE_PORT=7000
 ADMIN_PORT=7001
 MVSTORE_PID=""
@@ -82,6 +86,13 @@ check_prerequisites() {
 
     if [[ $missing -eq 1 ]]; then
         exit 1
+    fi
+
+    # Ensure ports are free
+    if lsof -ti :$MVSTORE_PORT -ti :$ADMIN_PORT &>/dev/null; then
+        echo "WARNING: Ports $MVSTORE_PORT/$ADMIN_PORT in use, killing existing processes..."
+        lsof -ti :$MVSTORE_PORT -ti :$ADMIN_PORT 2>/dev/null | xargs -r kill 2>/dev/null || true
+        sleep 2
     fi
 }
 
@@ -151,8 +162,8 @@ start_mvstore() {
     RUST_LOG=error "$MVSTORE" \
         --data-plane "127.0.0.1:$MVSTORE_PORT" \
         --admin-api "127.0.0.1:$ADMIN_PORT" \
-        --metadata-prefix mvstore-bench \
-        --raw-data-prefix b \
+        --metadata-prefix "mvbench-$(date +%s)" \
+        --raw-data-prefix "b$(date +%s)" \
         --auto-create-namespace \
         --content-cache-size "$content_cache_size" &
     MVSTORE_PID=$!
@@ -198,9 +209,9 @@ run_speedtest1() {
         RUST_LOG=error \
         "$SPEEDTEST1" "$ns" 2>&1) || true
 
-    # Parse TOTAL line: "     TOTAL                                          1.234s"
+    # Parse TOTAL line: "       TOTAL.......................................................   20.509s"
     local total
-    total=$(echo "$output" | grep -oP 'TOTAL\s+\K[0-9.]+(?=s)' || echo "0")
+    total=$(echo "$output" | grep -oP 'TOTAL[. ]+\K[0-9]+\.[0-9]+(?=s)' || echo "0")
     echo "$total"
 }
 

--- a/res/ci/prefetch_workloads.c
+++ b/res/ci/prefetch_workloads.c
@@ -89,6 +89,28 @@ static int drain_rows(sqlite3_stmt *stmt) {
     return count;
 }
 
+/* Query mv_prefetch_metrics('main') and print the JSON result.
+ * Output format: METRICS <workload> <json>
+ * The function is a no-op if mv_prefetch_metrics is not available. */
+static void print_prefetch_metrics(sqlite3 *db, const char *workload_name) {
+    sqlite3_stmt *stmt;
+    int rc = sqlite3_prepare_v2(db,
+        "SELECT mv_prefetch_metrics('main')", -1, &stmt, NULL);
+    if (rc != SQLITE_OK) {
+        /* Function not available (e.g., not running under mvsqlite) */
+        return;
+    }
+    rc = sqlite3_step(stmt);
+    if (rc == SQLITE_ROW) {
+        const char *json = (const char *)sqlite3_column_text(stmt, 0);
+        if (json) {
+            printf("METRICS %s %s\n", workload_name, json);
+            fflush(stdout);
+        }
+    }
+    sqlite3_finalize(stmt);
+}
+
 /* ---------- Padding data for realistic row sizes ---------- */
 
 static const char padding_chars[] =
@@ -561,6 +583,8 @@ int main(int argc, char **argv) {
                     exec_or_die(db, "PRAGMA journal_mode=DELETE");
                     times[j] = wl->run(db);
                 }
+                /* Print metrics from the last iteration (db still open) */
+                print_prefetch_metrics(db, wl->name);
                 double med = median(times, n);
                 printf("RESULT %s %.6f %.6f %.6f\n",
                        wl->name, med, times[0], times[n - 1]);
@@ -586,6 +610,7 @@ int main(int argc, char **argv) {
                 exec_or_die(db, "PRAGMA journal_mode=DELETE");
                 times[j] = wl->run(db);
             }
+            print_prefetch_metrics(db, wl->name);
             double med = median(times, n);
             printf("RESULT %s %.6f %.6f %.6f\n",
                    wl->name, med, times[0], times[n - 1]);

--- a/res/ci/prefetch_workloads.c
+++ b/res/ci/prefetch_workloads.c
@@ -549,6 +549,16 @@ int main(int argc, char **argv) {
                 int n = iterations > 64 ? 64 : iterations;
                 fprintf(stderr, "Running: %s (%d iterations)\n", wl->name, n);
                 for (int j = 0; j < n; j++) {
+                    /* Close and reopen DB between iterations and between
+                     * workloads to get a fresh page cache each time. */
+                    sqlite3_close(db);
+                    rc = sqlite3_open(db_path, &db);
+                    if (rc != SQLITE_OK) {
+                        fprintf(stderr, "Cannot reopen database: %s\n",
+                                sqlite3_errmsg(db));
+                        return 1;
+                    }
+                    exec_or_die(db, "PRAGMA journal_mode=DELETE");
                     times[j] = wl->run(db);
                 }
                 double med = median(times, n);
@@ -566,6 +576,14 @@ int main(int argc, char **argv) {
             int n = iterations > 64 ? 64 : iterations;
             fprintf(stderr, "Running: %s (%d iterations)\n", wl->name, n);
             for (int j = 0; j < n; j++) {
+                sqlite3_close(db);
+                rc = sqlite3_open(db_path, &db);
+                if (rc != SQLITE_OK) {
+                    fprintf(stderr, "Cannot reopen database: %s\n",
+                            sqlite3_errmsg(db));
+                    return 1;
+                }
+                exec_or_die(db, "PRAGMA journal_mode=DELETE");
                 times[j] = wl->run(db);
             }
             double med = median(times, n);

--- a/res/ci/prefetch_workloads.c
+++ b/res/ci/prefetch_workloads.c
@@ -1,0 +1,582 @@
+/*
+ * prefetch_workloads.c - End-to-end benchmark for mvsqlite prefetcher
+ *
+ * Targeted SQL workloads that stress different page access patterns.
+ * Links against the patched libsqlite3.so (with mvsqlite statically linked).
+ *
+ * Usage:
+ *   ./prefetch_workloads <db_path> setup <workload>   # create tables, populate data
+ *   ./prefetch_workloads <db_path> run <workload> [N]  # run workload N times (default 3)
+ *   ./prefetch_workloads <db_path> setup all           # setup all workloads
+ *   ./prefetch_workloads <db_path> run all [N]         # run all workloads
+ *
+ * Output (run mode):
+ *   RESULT <workload> <median_secs> <min_secs> <max_secs>
+ */
+
+#include <sqlite3.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+
+/* ---------- PRNG (xorshift32, deterministic) ---------- */
+
+static uint32_t rng_state = 0x12345678;
+
+static void rng_seed(uint32_t s) {
+    rng_state = s ? s : 1;
+}
+
+static uint32_t rng_next(void) {
+    uint32_t x = rng_state;
+    x ^= x << 13;
+    x ^= x >> 17;
+    x ^= x << 5;
+    rng_state = x;
+    return x;
+}
+
+static uint32_t rng_range(uint32_t max) {
+    return rng_next() % max;
+}
+
+/* ---------- Timing ---------- */
+
+static double now_secs(void) {
+    struct timespec ts;
+    clock_gettime(CLOCK_MONOTONIC, &ts);
+    return (double)ts.tv_sec + (double)ts.tv_nsec * 1e-9;
+}
+
+/* ---------- SQLite helpers ---------- */
+
+static void exec_or_die(sqlite3 *db, const char *sql) {
+    char *err = NULL;
+    int rc = sqlite3_exec(db, sql, NULL, NULL, &err);
+    if (rc != SQLITE_OK) {
+        fprintf(stderr, "SQL error on [%.60s...]: %s\n", sql, err ? err : "unknown");
+        sqlite3_free(err);
+        exit(1);
+    }
+}
+
+static sqlite3_stmt *prepare_or_die(sqlite3 *db, const char *sql) {
+    sqlite3_stmt *stmt;
+    int rc = sqlite3_prepare_v2(db, sql, -1, &stmt, NULL);
+    if (rc != SQLITE_OK) {
+        fprintf(stderr, "Prepare error on [%.60s...]: %s\n", sql, sqlite3_errmsg(db));
+        exit(1);
+    }
+    return stmt;
+}
+
+static void step_done(sqlite3 *db, sqlite3_stmt *stmt) {
+    int rc = sqlite3_step(stmt);
+    if (rc != SQLITE_DONE && rc != SQLITE_ROW) {
+        fprintf(stderr, "Step error: %s\n", sqlite3_errmsg(db));
+        exit(1);
+    }
+}
+
+/* Drain all rows from a statement, counting them */
+static int drain_rows(sqlite3_stmt *stmt) {
+    int count = 0;
+    while (sqlite3_step(stmt) == SQLITE_ROW) {
+        count++;
+    }
+    return count;
+}
+
+/* ---------- Padding data for realistic row sizes ---------- */
+
+static const char padding_chars[] =
+    "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
+
+static void fill_padding(char *buf, int len) {
+    for (int i = 0; i < len; i++) {
+        buf[i] = padding_chars[rng_range(sizeof(padding_chars) - 1)];
+    }
+    buf[len] = '\0';
+}
+
+/* ================================================================
+ * WORKLOAD A: seq_scan - Large sequential table scan
+ * ================================================================ */
+
+#define SEQ_SCAN_ROWS 100000
+#define SEQ_SCAN_PAD  200
+
+static void setup_seq_scan(sqlite3 *db) {
+    char pad[SEQ_SCAN_PAD + 1];
+
+    exec_or_die(db, "DROP TABLE IF EXISTS scan_test");
+    exec_or_die(db, "CREATE TABLE scan_test(id INTEGER PRIMARY KEY, data TEXT)");
+    exec_or_die(db, "BEGIN");
+
+    sqlite3_stmt *stmt = prepare_or_die(db,
+        "INSERT INTO scan_test(id, data) VALUES(?, ?)");
+
+    for (int i = 1; i <= SEQ_SCAN_ROWS; i++) {
+        fill_padding(pad, SEQ_SCAN_PAD);
+        sqlite3_bind_int(stmt, 1, i);
+        sqlite3_bind_text(stmt, 2, pad, -1, SQLITE_TRANSIENT);
+        sqlite3_step(stmt);
+        sqlite3_reset(stmt);
+    }
+    sqlite3_finalize(stmt);
+    exec_or_die(db, "COMMIT");
+}
+
+static double run_seq_scan(sqlite3 *db) {
+    double t0 = now_secs();
+    exec_or_die(db, "BEGIN");
+    sqlite3_stmt *stmt = prepare_or_die(db, "SELECT * FROM scan_test");
+    int rows = drain_rows(stmt);
+    sqlite3_finalize(stmt);
+    exec_or_die(db, "COMMIT");
+    double elapsed = now_secs() - t0;
+    fprintf(stderr, "  seq_scan: %d rows in %.3fs\n", rows, elapsed);
+    return elapsed;
+}
+
+/* ================================================================
+ * WORKLOAD B: rev_scan - Reverse sequential scan
+ * ================================================================ */
+
+/* Reuses scan_test table from seq_scan setup */
+
+static void setup_rev_scan(sqlite3 *db) {
+    /* Table already created by seq_scan setup */
+    (void)db;
+}
+
+static double run_rev_scan(sqlite3 *db) {
+    double t0 = now_secs();
+    exec_or_die(db, "BEGIN");
+    sqlite3_stmt *stmt = prepare_or_die(db,
+        "SELECT * FROM scan_test ORDER BY id DESC");
+    int rows = drain_rows(stmt);
+    sqlite3_finalize(stmt);
+    exec_or_die(db, "COMMIT");
+    double elapsed = now_secs() - t0;
+    fprintf(stderr, "  rev_scan: %d rows in %.3fs\n", rows, elapsed);
+    return elapsed;
+}
+
+/* ================================================================
+ * WORKLOAD C: idx_range - Index range scan
+ * ================================================================ */
+
+#define IDX_RANGE_ROWS 100000
+#define IDX_RANGE_PAD  200
+
+static void setup_idx_range(sqlite3 *db) {
+    char pad[IDX_RANGE_PAD + 1];
+
+    exec_or_die(db, "DROP TABLE IF EXISTS range_test");
+    exec_or_die(db, "CREATE TABLE range_test(id INTEGER PRIMARY KEY, val INTEGER, data TEXT)");
+    exec_or_die(db, "BEGIN");
+
+    sqlite3_stmt *stmt = prepare_or_die(db,
+        "INSERT INTO range_test(id, val, data) VALUES(?, ?, ?)");
+
+    rng_seed(0xCAFEBABE);
+    for (int i = 1; i <= IDX_RANGE_ROWS; i++) {
+        fill_padding(pad, IDX_RANGE_PAD);
+        sqlite3_bind_int(stmt, 1, i);
+        sqlite3_bind_int(stmt, 2, (int)rng_range(100000));
+        sqlite3_bind_text(stmt, 3, pad, -1, SQLITE_TRANSIENT);
+        sqlite3_step(stmt);
+        sqlite3_reset(stmt);
+    }
+    sqlite3_finalize(stmt);
+    exec_or_die(db, "COMMIT");
+    exec_or_die(db, "CREATE INDEX idx_range_val ON range_test(val)");
+}
+
+static double run_idx_range(sqlite3 *db) {
+    double t0 = now_secs();
+    exec_or_die(db, "BEGIN");
+    sqlite3_stmt *stmt = prepare_or_die(db,
+        "SELECT * FROM range_test WHERE val BETWEEN 1000 AND 5000 ORDER BY val");
+    int rows = drain_rows(stmt);
+    sqlite3_finalize(stmt);
+    exec_or_die(db, "COMMIT");
+    double elapsed = now_secs() - t0;
+    fprintf(stderr, "  idx_range: %d rows in %.3fs\n", rows, elapsed);
+    return elapsed;
+}
+
+/* ================================================================
+ * WORKLOAD D: point_lookup - Random point lookups
+ * ================================================================ */
+
+#define POINT_LOOKUP_ROWS   100000
+#define POINT_LOOKUP_PAD    200
+#define POINT_LOOKUP_QUERIES 10000
+
+static void setup_point_lookup(sqlite3 *db) {
+    char pad[POINT_LOOKUP_PAD + 1];
+
+    exec_or_die(db, "DROP TABLE IF EXISTS point_test");
+    exec_or_die(db, "CREATE TABLE point_test(id INTEGER PRIMARY KEY, data TEXT)");
+    exec_or_die(db, "BEGIN");
+
+    sqlite3_stmt *stmt = prepare_or_die(db,
+        "INSERT INTO point_test(id, data) VALUES(?, ?)");
+
+    for (int i = 1; i <= POINT_LOOKUP_ROWS; i++) {
+        fill_padding(pad, POINT_LOOKUP_PAD);
+        sqlite3_bind_int(stmt, 1, i);
+        sqlite3_bind_text(stmt, 2, pad, -1, SQLITE_TRANSIENT);
+        sqlite3_step(stmt);
+        sqlite3_reset(stmt);
+    }
+    sqlite3_finalize(stmt);
+    exec_or_die(db, "COMMIT");
+}
+
+static double run_point_lookup(sqlite3 *db) {
+    double t0 = now_secs();
+    exec_or_die(db, "BEGIN");
+
+    sqlite3_stmt *stmt = prepare_or_die(db,
+        "SELECT * FROM point_test WHERE id = ?");
+
+    rng_seed(0xDEADBEEF);
+    int hits = 0;
+    for (int i = 0; i < POINT_LOOKUP_QUERIES; i++) {
+        int id = 1 + (int)rng_range(POINT_LOOKUP_ROWS);
+        sqlite3_bind_int(stmt, 1, id);
+        if (sqlite3_step(stmt) == SQLITE_ROW) hits++;
+        sqlite3_reset(stmt);
+    }
+    sqlite3_finalize(stmt);
+    exec_or_die(db, "COMMIT");
+    double elapsed = now_secs() - t0;
+    fprintf(stderr, "  point_lookup: %d/%d hits in %.3fs\n",
+            hits, POINT_LOOKUP_QUERIES, elapsed);
+    return elapsed;
+}
+
+/* ================================================================
+ * WORKLOAD E: btree_probe - Repeated index probes by TEXT key
+ * ================================================================ */
+
+#define BTREE_PROBE_ROWS    100000
+#define BTREE_PROBE_PAD     200
+#define BTREE_PROBE_QUERIES 10000
+
+static void setup_btree_probe(sqlite3 *db) {
+    char pad[BTREE_PROBE_PAD + 1];
+    char key[32];
+
+    exec_or_die(db, "DROP TABLE IF EXISTS btree_test");
+    exec_or_die(db, "CREATE TABLE btree_test(id INTEGER PRIMARY KEY, key TEXT, val TEXT)");
+    exec_or_die(db, "BEGIN");
+
+    sqlite3_stmt *stmt = prepare_or_die(db,
+        "INSERT INTO btree_test(id, key, val) VALUES(?, ?, ?)");
+
+    for (int i = 1; i <= BTREE_PROBE_ROWS; i++) {
+        snprintf(key, sizeof(key), "key_%08d", i);
+        fill_padding(pad, BTREE_PROBE_PAD);
+        sqlite3_bind_int(stmt, 1, i);
+        sqlite3_bind_text(stmt, 2, key, -1, SQLITE_TRANSIENT);
+        sqlite3_bind_text(stmt, 3, pad, -1, SQLITE_TRANSIENT);
+        sqlite3_step(stmt);
+        sqlite3_reset(stmt);
+    }
+    sqlite3_finalize(stmt);
+    exec_or_die(db, "COMMIT");
+    exec_or_die(db, "CREATE INDEX idx_btree_key ON btree_test(key)");
+}
+
+static double run_btree_probe(sqlite3 *db) {
+    char key[32];
+    double t0 = now_secs();
+    exec_or_die(db, "BEGIN");
+
+    sqlite3_stmt *stmt = prepare_or_die(db,
+        "SELECT * FROM btree_test WHERE key = ?");
+
+    rng_seed(0xFEEDFACE);
+    int hits = 0;
+    for (int i = 0; i < BTREE_PROBE_QUERIES; i++) {
+        int id = 1 + (int)rng_range(BTREE_PROBE_ROWS);
+        snprintf(key, sizeof(key), "key_%08d", id);
+        sqlite3_bind_text(stmt, 1, key, -1, SQLITE_TRANSIENT);
+        if (sqlite3_step(stmt) == SQLITE_ROW) hits++;
+        sqlite3_reset(stmt);
+    }
+    sqlite3_finalize(stmt);
+    exec_or_die(db, "COMMIT");
+    double elapsed = now_secs() - t0;
+    fprintf(stderr, "  btree_probe: %d/%d hits in %.3fs\n",
+            hits, BTREE_PROBE_QUERIES, elapsed);
+    return elapsed;
+}
+
+/* ================================================================
+ * WORKLOAD F: mixed_rw - Interleaved reads and writes
+ * ================================================================ */
+
+#define MIXED_RW_ROWS   10000
+#define MIXED_RW_PAD    200
+#define MIXED_RW_ITERS  1000
+
+static void setup_mixed_rw(sqlite3 *db) {
+    char pad[MIXED_RW_PAD + 1];
+
+    exec_or_die(db, "DROP TABLE IF EXISTS mixed_test");
+    exec_or_die(db, "CREATE TABLE mixed_test(id INTEGER PRIMARY KEY, counter INTEGER, data TEXT)");
+    exec_or_die(db, "BEGIN");
+
+    sqlite3_stmt *stmt = prepare_or_die(db,
+        "INSERT INTO mixed_test(id, counter, data) VALUES(?, 0, ?)");
+
+    for (int i = 1; i <= MIXED_RW_ROWS; i++) {
+        fill_padding(pad, MIXED_RW_PAD);
+        sqlite3_bind_int(stmt, 1, i);
+        sqlite3_bind_text(stmt, 2, pad, -1, SQLITE_TRANSIENT);
+        sqlite3_step(stmt);
+        sqlite3_reset(stmt);
+    }
+    sqlite3_finalize(stmt);
+    exec_or_die(db, "COMMIT");
+}
+
+static double run_mixed_rw(sqlite3 *db) {
+    double t0 = now_secs();
+
+    sqlite3_stmt *sel = prepare_or_die(db,
+        "SELECT counter, data FROM mixed_test WHERE id = ?");
+    sqlite3_stmt *upd = prepare_or_die(db,
+        "UPDATE mixed_test SET counter = counter + 1 WHERE id = ?");
+
+    rng_seed(0xBAADF00D);
+    for (int i = 0; i < MIXED_RW_ITERS; i++) {
+        int id1 = 1 + (int)rng_range(MIXED_RW_ROWS);
+        int id2 = 1 + (int)rng_range(MIXED_RW_ROWS);
+        int id3 = 1 + (int)rng_range(MIXED_RW_ROWS);
+
+        exec_or_die(db, "BEGIN");
+
+        /* Read */
+        sqlite3_bind_int(sel, 1, id1);
+        sqlite3_step(sel);
+        sqlite3_reset(sel);
+
+        /* Write */
+        sqlite3_bind_int(upd, 1, id2);
+        sqlite3_step(upd);
+        sqlite3_reset(upd);
+
+        /* Read */
+        sqlite3_bind_int(sel, 1, id3);
+        sqlite3_step(sel);
+        sqlite3_reset(sel);
+
+        exec_or_die(db, "COMMIT");
+    }
+
+    sqlite3_finalize(sel);
+    sqlite3_finalize(upd);
+    double elapsed = now_secs() - t0;
+    fprintf(stderr, "  mixed_rw: %d iterations in %.3fs\n", MIXED_RW_ITERS, elapsed);
+    return elapsed;
+}
+
+/* ================================================================
+ * WORKLOAD G: repeated_scan - Same table scanned multiple times
+ * ================================================================ */
+
+#define REPEATED_SCAN_ROWS  50000
+#define REPEATED_SCAN_PAD   200
+#define REPEATED_SCAN_ITERS 5
+
+static void setup_repeated_scan(sqlite3 *db) {
+    char pad[REPEATED_SCAN_PAD + 1];
+
+    exec_or_die(db, "DROP TABLE IF EXISTS repeat_test");
+    exec_or_die(db, "CREATE TABLE repeat_test(id INTEGER PRIMARY KEY, data TEXT)");
+    exec_or_die(db, "BEGIN");
+
+    sqlite3_stmt *stmt = prepare_or_die(db,
+        "INSERT INTO repeat_test(id, data) VALUES(?, ?)");
+
+    rng_seed(0xC0FFEE42);
+    for (int i = 1; i <= REPEATED_SCAN_ROWS; i++) {
+        fill_padding(pad, REPEATED_SCAN_PAD);
+        sqlite3_bind_int(stmt, 1, i);
+        sqlite3_bind_text(stmt, 2, pad, -1, SQLITE_TRANSIENT);
+        sqlite3_step(stmt);
+        sqlite3_reset(stmt);
+    }
+    sqlite3_finalize(stmt);
+    exec_or_die(db, "COMMIT");
+}
+
+static double run_repeated_scan(sqlite3 *db) {
+    const char *patterns[] = {
+        "%aBC%", "%XyZ%", "%mNO%", "%qRS%", "%JKL%"
+    };
+    double t0 = now_secs();
+
+    for (int i = 0; i < REPEATED_SCAN_ITERS; i++) {
+        exec_or_die(db, "BEGIN");
+        sqlite3_stmt *stmt = prepare_or_die(db,
+            "SELECT count(*) FROM repeat_test WHERE data LIKE ?");
+        sqlite3_bind_text(stmt, 1, patterns[i], -1, SQLITE_STATIC);
+        sqlite3_step(stmt);
+        int cnt = sqlite3_column_int(stmt, 0);
+        sqlite3_finalize(stmt);
+        exec_or_die(db, "COMMIT");
+        fprintf(stderr, "  repeated_scan iter %d: %d matches\n", i, cnt);
+    }
+
+    double elapsed = now_secs() - t0;
+    fprintf(stderr, "  repeated_scan: %d iterations in %.3fs\n",
+            REPEATED_SCAN_ITERS, elapsed);
+    return elapsed;
+}
+
+/* ================================================================
+ * Workload dispatch table
+ * ================================================================ */
+
+typedef struct {
+    const char *name;
+    void (*setup)(sqlite3 *);
+    double (*run)(sqlite3 *);
+    int needs_prior_setup; /* 1 if depends on another workload's setup */
+} Workload;
+
+/* NOTE: rev_scan reuses scan_test from seq_scan, so seq_scan must be set up first */
+static Workload workloads[] = {
+    {"seq_scan",      setup_seq_scan,      run_seq_scan,      0},
+    {"rev_scan",      setup_rev_scan,      run_rev_scan,      1},
+    {"idx_range",     setup_idx_range,     run_idx_range,     0},
+    {"point_lookup",  setup_point_lookup,  run_point_lookup,  0},
+    {"btree_probe",   setup_btree_probe,   run_btree_probe,   0},
+    {"mixed_rw",      setup_mixed_rw,      run_mixed_rw,      0},
+    {"repeated_scan", setup_repeated_scan, run_repeated_scan, 0},
+    {NULL, NULL, NULL, 0}
+};
+
+static Workload *find_workload(const char *name) {
+    for (int i = 0; workloads[i].name; i++) {
+        if (strcmp(workloads[i].name, name) == 0)
+            return &workloads[i];
+    }
+    return NULL;
+}
+
+/* ---------- Median helper ---------- */
+
+static int cmp_double(const void *a, const void *b) {
+    double da = *(const double *)a;
+    double db = *(const double *)b;
+    if (da < db) return -1;
+    if (da > db) return 1;
+    return 0;
+}
+
+static double median(double *arr, int n) {
+    qsort(arr, n, sizeof(double), cmp_double);
+    if (n % 2 == 1)
+        return arr[n / 2];
+    return (arr[n / 2 - 1] + arr[n / 2]) / 2.0;
+}
+
+/* ================================================================
+ * Main
+ * ================================================================ */
+
+static void usage(const char *prog) {
+    fprintf(stderr,
+        "Usage:\n"
+        "  %s <db_path> setup <workload|all>\n"
+        "  %s <db_path> run <workload|all> [iterations]\n"
+        "\nWorkloads: seq_scan rev_scan idx_range point_lookup "
+        "btree_probe mixed_rw repeated_scan\n",
+        prog, prog);
+    exit(1);
+}
+
+int main(int argc, char **argv) {
+    if (argc < 4) usage(argv[0]);
+
+    const char *db_path = argv[1];
+    const char *mode = argv[2];
+    const char *wl_name = argv[3];
+    int iterations = 3;
+    if (argc >= 5) iterations = atoi(argv[4]);
+    if (iterations < 1) iterations = 1;
+
+    sqlite3 *db;
+    int rc = sqlite3_open(db_path, &db);
+    if (rc != SQLITE_OK) {
+        fprintf(stderr, "Cannot open database %s: %s\n", db_path, sqlite3_errmsg(db));
+        return 1;
+    }
+
+    /* WAL mode is not supported by mvsqlite, use delete journal mode */
+    exec_or_die(db, "PRAGMA journal_mode=DELETE");
+
+    if (strcmp(mode, "setup") == 0) {
+        if (strcmp(wl_name, "all") == 0) {
+            for (int i = 0; workloads[i].name; i++) {
+                fprintf(stderr, "Setting up: %s\n", workloads[i].name);
+                workloads[i].setup(db);
+            }
+        } else {
+            Workload *wl = find_workload(wl_name);
+            if (!wl) {
+                fprintf(stderr, "Unknown workload: %s\n", wl_name);
+                return 1;
+            }
+            fprintf(stderr, "Setting up: %s\n", wl->name);
+            wl->setup(db);
+        }
+    } else if (strcmp(mode, "run") == 0) {
+        if (strcmp(wl_name, "all") == 0) {
+            for (int i = 0; workloads[i].name; i++) {
+                Workload *wl = &workloads[i];
+                double times[64];
+                int n = iterations > 64 ? 64 : iterations;
+                fprintf(stderr, "Running: %s (%d iterations)\n", wl->name, n);
+                for (int j = 0; j < n; j++) {
+                    times[j] = wl->run(db);
+                }
+                double med = median(times, n);
+                printf("RESULT %s %.6f %.6f %.6f\n",
+                       wl->name, med, times[0], times[n - 1]);
+                fflush(stdout);
+            }
+        } else {
+            Workload *wl = find_workload(wl_name);
+            if (!wl) {
+                fprintf(stderr, "Unknown workload: %s\n", wl_name);
+                return 1;
+            }
+            double times[64];
+            int n = iterations > 64 ? 64 : iterations;
+            fprintf(stderr, "Running: %s (%d iterations)\n", wl->name, n);
+            for (int j = 0; j < n; j++) {
+                times[j] = wl->run(db);
+            }
+            double med = median(times, n);
+            printf("RESULT %s %.6f %.6f %.6f\n",
+                   wl->name, med, times[0], times[n - 1]);
+            fflush(stdout);
+        }
+    } else {
+        usage(argv[0]);
+    }
+
+    sqlite3_close(db);
+    return 0;
+}


### PR DESCRIPTION
## Summary
This PR adds a comprehensive benchmarking suite to measure the performance impact of mvsqlite's prefetcher across various SQL workload patterns. The suite includes both a custom workload harness and integration with SQLite's speedtest1 benchmark.

## Key Changes

- **prefetch_workloads.c**: New C benchmark program that implements 7 targeted SQL workloads:
  - `seq_scan`: Large sequential table scan (100k rows)
  - `rev_scan`: Reverse sequential scan with index ordering
  - `idx_range`: Index range queries with BETWEEN predicates
  - `point_lookup`: Random point lookups (10k queries)
  - `btree_probe`: Repeated index probes by TEXT key
  - `mixed_rw`: Interleaved reads and writes
  - `repeated_scan`: Multiple scans with LIKE pattern matching
  
  Each workload includes setup and run phases with configurable iterations and median/min/max timing statistics.

- **prefetch_bench.sh**: Comprehensive bash benchmark harness that:
  - Orchestrates the full benchmark matrix (prefetch depths, cache sizes, workloads)
  - Manages mvstore lifecycle (start/stop with varying configurations)
  - Builds patched SQLite3 with mvsqlite integration
  - Compiles the workload binary and speedtest1
  - Collects results in CSV format and generates comparison tables
  - Calculates speedup ratios relative to baseline (depth=0)
  - Supports quick mode for rapid testing (depth 0 and 8 only)

## Implementation Details

- Workloads use deterministic PRNG (xorshift32) for reproducible random access patterns
- Realistic row sizes with padding (200-byte data fields) to stress page prefetching
- Median-based timing statistics across multiple runs to reduce noise
- Results output in both CSV and formatted text tables with speedup calculations
- Supports testing with different prefetch depths (0, 4, 8, 16, 32) and cache configurations
- Integration with FoundationDB via mvsqlite's data plane API

https://claude.ai/code/session_015RQigaGivKaC5RjuAsmiji