### PR TITLE
Fix nslock rollback correctness with commits, GC, and overlays

### DIFF
--- a/docs/nslock_analysis.md
+++ b/docs/nslock_analysis.md
@@ -87,9 +87,10 @@ validation compose correctly.
 1. reads namespace metadata;
 2. rejects if another owner holds the lock;
 3. reads `last_write_version` with `snapshot=false`;
-4. chooses `snapshot_version`;
-5. writes `metadata.lock = Some(...)`;
-6. commits, retrying on conflict.
+4. for explicit versions, rejects rollback-ineligible snapshots;
+5. chooses `snapshot_version`;
+6. writes `metadata.lock = Some(...)`;
+7. commits, retrying on conflict.
 
 The non-snapshot `last_write_version` read is essential. A concurrent commit
 writes `last_write_version` with `SetVersionstampedValue`. Thus an acquire that
@@ -109,7 +110,17 @@ Thus a successful acquire linearizes at its metadata commit. Its
 before the lock.
 
 For explicit rollback targets, acquire additionally rejects a requested version
-newer than the namespace head or older than `truncated_before`.
+newer than the namespace head, older than `truncated_before`, or older than the
+minimum overlay child snapshot for this namespace.
+
+The overlay-child check is performed during acquire rather than only during
+rollback release. This prevents a client from acquiring a lock that can never
+be rolled back and then discovering the problem only at release time. The
+overlay reference scan is non-snapshot, so a concurrent `create_namespace`
+that writes an overlay reference conflicts with acquire if it races between the
+scan and the metadata commit. If acquire commits first, the child creation
+transaction conflicts on the base namespace metadata read or observes the lock
+and is rejected.
 
 ## Commit While Locked
 
@@ -167,7 +178,7 @@ Rollback has three logical phases.
 
 ### Phase 1: Mark Rolling Back
 
-The first transaction verifies ownership, checks overlay children, sets
+The first transaction verifies ownership, rechecks overlay children, sets
 `lock.rolling_back = true`, clears the rollback cursor, and commits.
 
 After this transaction commits, no transaction can start and successfully commit
@@ -181,9 +192,12 @@ as the owner:
 
 Non-owner commits are already blocked by the lock.
 
-The mark phase also checks overlay reverse references. If any child namespace
-depends on the base at a snapshot newer than the rollback target, rollback is
-rejected. This prevents changing what an existing overlay child reads from its
+The mark phase keeps an overlay reverse-reference check even though acquire
+already rejects rollback-ineligible explicit snapshots. This is a defensive
+guard for locks acquired before the validation existed and for resumed
+rollbacks. If any child namespace depends on the base at a snapshot newer than
+the rollback target, rollback is rejected before any page-index entry is
+deleted. This prevents changing what an existing overlay child reads from its
 base.
 
 ### Phase 2: Delete Newer Page Versions
@@ -277,11 +291,13 @@ content, but it does not publish corrupt page state.
 ## Interaction With Overlay Namespaces
 
 Overlay children pin a base namespace at `overlay_base.snapshot_version`.
-`nslock` preserves that invariant in two places:
+`nslock` preserves that invariant in three places:
 
+- explicit-version acquire rejects a lock snapshot older than any existing
+  overlay child snapshot;
 - `create_namespace` rejects creating an overlay from a locked base namespace;
-- rollback scans existing overlay references and rejects a rollback target older
-  than any child snapshot.
+- rollback release rechecks existing overlay references and rejects a rollback
+  target older than any child snapshot before marking `rolling_back`.
 
 Version truncation also clamps to the minimum overlay child snapshot. Together,
 these rules prevent rollback or GC from changing the base data visible to an

--- a/docs/nslock_analysis.md
+++ b/docs/nslock_analysis.md
@@ -1,0 +1,308 @@
+# Correctness Analysis of `nslock`
+
+This document analyzes the namespace lock implemented in
+`mvstore/src/nslock.rs`, with emphasis on interactions with transaction commit,
+rollback, GC, and overlay namespaces.
+
+## Claim
+
+Subject to the assumptions below, `nslock` is correct:
+
+1. Once `acquire_nslock` returns success, every later committed namespace write
+   is either made by the matching `lock_owner`, or is rejected/conflicts.
+2. `release_nslock(..., Commit)` removes the lock without losing committed
+   owner writes.
+3. `release_nslock(..., Rollback)` restores the namespace head to the lock's
+   `snapshot_version`: page-index entries and changelog entries newer than the
+   snapshot are removed, `last_write_version` is reset to the snapshot, and no
+   transaction can commit into the rollback window after rollback has been
+   marked.
+4. Concurrent version truncation and content GC do not delete data needed by
+   the locked snapshot or by the rolled-back namespace head.
+5. Overlay children continue to read a stable base snapshot.
+
+Assumptions:
+
+- FoundationDB transactions provide serializable conflict checking, with
+  non-snapshot reads and explicit conflict ranges behaving as expected.
+- `NamespaceMetadataCache::get` is treated as a read of the namespace metadata
+  key because it calls `add_single_key_read_conflict_range`, even though the
+  underlying `txn.get` is snapshot-read.
+- The lock owner string is a capability. If two clients intentionally use the
+  same owner string, they jointly own the lock.
+- Administrative destructive operations such as `delete_namespace` are outside
+  the pessimistic write-lock contract. They can remove a locked namespace. This
+  is an administrative override, not protection provided by `nslock`.
+
+## State Protected by the Lock
+
+The lock is stored in namespace metadata:
+
+```rust
+struct NamespaceLock {
+    snapshot_version: String,
+    owner: String,
+    nonce: String,
+    rolling_back: bool,
+}
+```
+
+The protected mutable namespace state is:
+
+- page-index keys `page(ns, page_index, version)`;
+- the namespace `last_write_version` key;
+- changelog keys;
+- namespace metadata, including the lock and truncation watermark.
+
+Content blobs and content-index entries are content-addressed staging data.
+Rollback does not delete them immediately; `delete_unreferenced_content` reclaims
+them after page references disappear.
+
+## Fundamental Metadata Conflict Invariant
+
+Every path that needs to honor a namespace lock reads namespace metadata through
+`NamespaceMetadataCache::get`. That function:
+
+1. obtains metadata, possibly from the cache;
+2. explicitly adds the namespace metadata key to the transaction's read conflict
+   set.
+
+Every lock state transition writes the same metadata key through
+`NamespaceMetadataCache::set`, which also updates FoundationDB metadata version.
+
+Therefore, for any committing transaction T that validated lock state, and any
+concurrent transaction L that changes lock state:
+
+- if L commits between T's metadata read and T's commit, T conflicts;
+- if T commits first, L observes either the old state or retries according to
+  the surrounding loop.
+
+This is the central reason commit, release, rollback marking, and rollback
+validation compose correctly.
+
+## Acquire
+
+`acquire_nslock`:
+
+1. reads namespace metadata;
+2. rejects if another owner holds the lock;
+3. reads `last_write_version` with `snapshot=false`;
+4. chooses `snapshot_version`;
+5. writes `metadata.lock = Some(...)`;
+6. commits, retrying on conflict.
+
+The non-snapshot `last_write_version` read is essential. A concurrent commit
+writes `last_write_version` with `SetVersionstampedValue`. Thus an acquire that
+chooses a snapshot from an old head conflicts if a commit reaches the namespace
+before acquire commits.
+
+Consider a commit C and acquire A racing on an unlocked namespace:
+
+- If C reads metadata before A commits, then A's metadata write conflicts with
+  C's metadata read if A commits first.
+- If C commits first, C's `last_write_version` write conflicts with A's
+  non-snapshot `last_write_version` read, so A retries and chooses a snapshot
+  at least as new as C.
+
+Thus a successful acquire linearizes at its metadata commit. Its
+`snapshot_version` is not behind any commit that also successfully linearized
+before the lock.
+
+For explicit rollback targets, acquire additionally rejects a requested version
+newer than the namespace head or older than `truncated_before`.
+
+## Commit While Locked
+
+`Server::commit` checks the lock in phase 2, after any multi-phase staging:
+
+```text
+lock exists, matching owner, not rolling_back => proceed
+lock exists, no owner                         => Conflict
+lock exists, wrong owner                      => Gone
+lock exists, rolling_back                     => Gone
+no lock, lock_owner supplied                  => Gone
+```
+
+Because the metadata read is in the read conflict set, a transaction that saw a
+valid lock cannot commit if the lock is removed or marked rolling back before
+the transaction commits.
+
+This holds for all commit modes:
+
+- non-PLCC single-phase commits;
+- PLCC single-phase commits;
+- multi-phase commits.
+
+In the multi-phase path, phase 1 may write content blobs and a commit token
+before lock validation. That does not publish namespace data because page-index
+entries, changelog entries, and `last_write_version` are written only in phase
+2. If phase 2 fails the lock check, phase 1 leaves at most unreferenced content,
+which content GC may later collect.
+
+## Release In Commit Mode
+
+Commit-mode release reads metadata, verifies the owner, rejects if rollback has
+started, clears `metadata.lock`, and commits.
+
+Race with an owner commit:
+
+- If release commits before the owner commit, the owner commit's metadata read
+  conflicts with the release metadata write.
+- If the owner commit commits first, release can then remove the lock. The
+  owner write remains published, which is exactly commit-mode release semantics.
+
+Race with a non-owner commit:
+
+- Before release commits, non-owner commits observe a lock and return
+  `Conflict` or `Gone`.
+- After release commits, normal optimistic commit rules apply.
+
+Therefore commit-mode release does not admit a write in the locked interval by
+any non-owner, and it does not erase an owner write that committed before the
+release linearized.
+
+## Release In Rollback Mode
+
+Rollback has three logical phases.
+
+### Phase 1: Mark Rolling Back
+
+The first transaction verifies ownership, checks overlay children, sets
+`lock.rolling_back = true`, clears the rollback cursor, and commits.
+
+After this transaction commits, no transaction can start and successfully commit
+as the owner:
+
+- a later owner commit reads `rolling_back = true` and returns `Gone`;
+- an owner commit that read the previous lock state conflicts on the metadata
+  key if the mark transaction commits first;
+- if the owner commit commits first, it is a pre-mark write and is intentionally
+  included in rollback.
+
+Non-owner commits are already blocked by the lock.
+
+The mark phase also checks overlay reverse references. If any child namespace
+depends on the base at a snapshot newer than the rollback target, rollback is
+rejected. This prevents changing what an existing overlay child reads from its
+base.
+
+### Phase 2: Delete Newer Page Versions
+
+Rollback scans all page-index keys for the namespace and deletes entries whose
+version is greater than `snapshot_version`.
+
+Before each batch commit, `lock_is_still_valid` reads namespace metadata and
+checks the lock nonce. This has two effects:
+
+- if the lock was removed or replaced, rollback returns `410`;
+- if metadata changes after validation but before the batch commit, the batch
+  conflicts because the metadata key is in the read conflict set.
+
+The scan itself uses snapshot reads. This is safe because, after the mark phase,
+no new page-index entries can successfully commit under the lock. Any page entry
+newer than the snapshot was either committed before the mark phase and will be
+found by some scan batch, or was part of a transaction that loses the metadata
+race and does not commit.
+
+The rollback cursor is conservative. It may cause a restarted rollback to
+rescan part of a page index, but rescanning is idempotent because clearing a key
+that is already absent is harmless.
+
+### Phase 3: Finalize
+
+Finalization again validates the nonce, then in one transaction:
+
+1. sets `last_write_version` to `snapshot_version`;
+2. clears changelog keys newer than `snapshot_version`;
+3. clears `metadata.lock`.
+
+Because lock removal is atomic with the head/changelog repair, normal clients
+cannot observe an unlocked namespace whose `last_write_version` still points
+past the rollback target.
+
+After finalization, old transactions whose assumed version is newer than the
+rolled-back head are rejected by the commit path. The commit code checks
+`client_assumed_version > effective_last_write_version` even on the PLCC fast
+path, so a client that observed the pre-rollback head cannot publish a commit
+as if that head still existed.
+
+## Interaction With Version Truncation
+
+`truncate_versions` deletes old page versions, but it first writes a
+`truncated_before` watermark in a transaction that also reads:
+
+- namespace metadata;
+- overlay reverse references.
+
+If a lock exists, the effective truncation cutoff is clamped to
+`lock.snapshot_version`. Therefore truncation cannot delete page versions needed
+to read the locked snapshot.
+
+Races with acquire are covered by the metadata conflict invariant:
+
+- If acquire commits first, truncation's metadata read conflicts and truncation
+  retries, then sees the lock and clamps.
+- If truncation commits first, acquire's metadata read conflicts and acquire
+  retries, then sees `truncated_before` and rejects explicit lock targets before
+  the watermark.
+
+After the watermark transaction, page deletion preserves the latest page version
+in the truncated range. Thus a rollback target at or after the watermark remains
+readable.
+
+## Interaction With Content GC
+
+`delete_unreferenced_content` deletes content blobs only after checking page
+references and delta references. Rollback removes page-index entries newer than
+the target and intentionally leaves content blobs behind.
+
+Content needed by the rolled-back head remains protected because:
+
+- page-index entries at or before `snapshot_version` are not deleted by
+  rollback;
+- delta base references are tracked by the delta-referrer index;
+- content GC's correctness argument uses these references, content-index
+  versionstamps, commit tokens, and conflict ranges to avoid deleting content
+  referenced by a committed page entry.
+
+Content written after the rollback target may become unreferenced once rollback
+deletes newer page-index entries. Deleting that content later is correct because
+no surviving namespace head references it.
+
+Multi-phase commit staging remains safe with rollback and GC. If phase 1 writes
+content but phase 2 is blocked by the lock or by `rolling_back`, only
+unreferenced staged content remains. That can cause a later retry to rewrite
+content, but it does not publish corrupt page state.
+
+## Interaction With Overlay Namespaces
+
+Overlay children pin a base namespace at `overlay_base.snapshot_version`.
+`nslock` preserves that invariant in two places:
+
+- `create_namespace` rejects creating an overlay from a locked base namespace;
+- rollback scans existing overlay references and rejects a rollback target older
+  than any child snapshot.
+
+Version truncation also clamps to the minimum overlay child snapshot. Together,
+these rules prevent rollback or GC from changing the base data visible to an
+existing overlay child.
+
+## Limitations
+
+- Re-acquiring with the same owner is idempotent and does not change
+  `snapshot_version`. A fresh owner should be used for each distinct rollback
+  attempt.
+- The owner string is not a lease or authenticated session. Shared owner strings
+  mean shared write authority.
+- `nslock` protects the normal data-plane commit protocol and the GC/overlay
+  paths described here. It does not prevent administrative deletion of a
+  namespace.
+
+## Conclusion
+
+The mechanism is correct for its intended contract. The proof relies on one
+simple synchronization point, the namespace metadata key, plus the
+`last_write_version` read during acquire. Commit paths must validate metadata
+before publishing page-index entries, rollback must mark `rolling_back` before
+deleting page versions, and GC must honor lock snapshots and overlay references.
+The current implementation satisfies those requirements.

--- a/docs/rollback.md
+++ b/docs/rollback.md
@@ -1,0 +1,240 @@
+# Rolling a Namespace Back to an Old Version
+
+This document describes how a data-plane client can roll a namespace
+(SQLite database) back to a previous mvSQLite version.
+
+Rollback is implemented by the data-plane `nslock` mechanism:
+
+1. Acquire an exclusive namespace lock at the target snapshot version.
+2. Release that lock in `rollback` mode.
+
+The rollback is destructive. It deletes namespace page-index entries newer
+than the target version, resets the namespace last-write version to the target
+version, deletes newer changelog entries, and removes the lock.
+
+## When to Use This
+
+Use this when the current namespace head should be moved back to an older
+committed version.
+
+Do not confuse this with SQLite transaction rollback. SQLite transaction
+rollback only discards a single uncommitted transaction. Namespace rollback
+changes the persisted mvSQLite namespace head.
+
+## Prerequisites
+
+- A writable mvstore data-plane endpoint, for example
+  `http://localhost:7000`.
+- The namespace key, for example `test`.
+- A unique lock owner string, at most 256 bytes.
+- The target version, as a 20-character hex-encoded 10-byte mvSQLite version.
+
+If the namespace key uses hashproof protection, send both headers used by
+normal data-plane clients:
+
+```http
+x-namespace-key: <namespace-key-containing-hash>
+x-namespace-hashproof: <hex-proof>
+```
+
+For unprotected namespace keys, only `x-namespace-key` is required.
+
+## Choosing the Target Version
+
+Versions are hex-encoded FoundationDB versionstamps used by mvSQLite.
+
+Common ways to get a candidate version:
+
+- Save the `CommitResult.version` returned by `mvclient` after a successful
+  commit.
+- Call `GET /stat` against the namespace to get the current head version.
+- Call `GET /time2version?t=<unix-seconds>` to map a wall-clock time to nearby
+  versions.
+- From SQLite, call `mv_last_known_version('main')` after a transaction or
+  `mv_time2version('main', <unix-seconds>)`.
+
+Example current namespace head:
+
+```bash
+DP=http://localhost:7000
+NS=test
+
+curl -sS "$DP/stat" \
+  -H "x-namespace-key: $NS"
+```
+
+Example time lookup:
+
+```bash
+curl -sS "$DP/time2version?t=1710000000"
+```
+
+The response contains `after` and `not_after` points. `after` is the latest
+recorded timekeeper point before the requested timestamp, and `not_after` is
+the first point at or after it. For most "roll back to the database state
+around this time" workflows, use `after.version`; this is also what the SQLite
+`mv_time2version` helper returns.
+
+Before performing a destructive rollback, verify the selected snapshot by
+opening the namespace read-only at that version. In SQLite, either open
+`<namespace>@<version>` or pin the connection:
+
+```sql
+select mv_pin_version('main', '<target-version>');
+-- inspect the database
+select mv_unpin_version('main');
+```
+
+Writes to a pinned/fixed version are discarded by the VFS.
+
+## Rollback Procedure
+
+Set variables:
+
+```bash
+DP=http://localhost:7000
+NS=test
+OWNER=rollback-$(hostname)-$(date +%s)
+TARGET_VERSION=<20-char-hex-version>
+```
+
+Acquire the namespace lock at the target version:
+
+```bash
+curl -i -sS -X POST "$DP/nslock/acquire" \
+  -H "content-type: application/json" \
+  -H "x-namespace-key: $NS" \
+  -d "{\"owner\":\"$OWNER\",\"version\":\"$TARGET_VERSION\"}"
+```
+
+Expected success status: `201 Created`.
+
+Release the lock in rollback mode:
+
+```bash
+curl -i -sS -X POST "$DP/nslock/release" \
+  -H "content-type: application/json" \
+  -H "x-namespace-key: $NS" \
+  -d "{\"owner\":\"$OWNER\",\"mode\":\"rollback\"}"
+```
+
+Expected success status: `200 OK`.
+
+Verify that the lock is gone and that normal clients see the target version:
+
+```bash
+curl -sS "$DP/stat" \
+  -H "x-namespace-key: $NS"
+```
+
+If the admin API is available, also verify namespace metadata:
+
+```bash
+ADMIN=http://localhost:7001
+
+curl -sS -X POST "$ADMIN/api/stat_namespace" \
+  -H "content-type: application/json" \
+  -d "{\"key\":\"$NS\"}"
+```
+
+The metadata should have `"lock": null`.
+
+## What Other Clients See
+
+After `nslock/acquire` succeeds:
+
+- Normal readers that do not pass `lock_owner` see the lock's
+  `snapshot_version`, which is the target rollback version.
+- Normal writers that do not pass `lock_owner` conflict while the lock exists.
+- A client configured with the same lock owner can still stat and commit
+  against the live namespace while the lock is held.
+
+After `nslock/release` starts in `rollback` mode:
+
+- The lock is marked `rolling_back`.
+- The lock owner can no longer start or commit owned transactions.
+- Normal readers continue to see the target snapshot.
+- The release request scans page entries in batches and removes entries newer
+  than the target version.
+
+After rollback finishes:
+
+- The lock is removed.
+- The namespace last-write version is the target version.
+- Normal readers and writers use the rolled-back namespace head.
+
+## mvclient and SQLite Integration
+
+`mvclient` does not currently expose a high-level rollback method. A client
+that wants to roll back a namespace should issue the raw HTTP requests above.
+
+`MultiVersionClientConfig.lock_owner` is still important for clients that need
+to operate while holding a lock:
+
+- It appends `lock_owner=<owner>` to `/stat` requests.
+- It includes the owner in `/batch/commit`.
+
+The SQLite VFS reads the same value from the environment:
+
+```bash
+export MVSQLITE_LOCK_OWNER="$OWNER"
+```
+
+For a pure rollback to an old version, do not perform writes between lock
+acquisition and `rollback` release. Any page versions newer than the target are
+removed by the rollback.
+
+## Status Codes
+
+### `POST /nslock/acquire`
+
+| Status | Meaning |
+| --- | --- |
+| `201` | Lock acquired, or the same owner already owns it. |
+| `400` | Invalid owner, usually empty or more than 256 bytes. |
+| `404` | Namespace key was not found. |
+| `409` | Another owner holds the lock. The `x-lock-owner` header identifies it. |
+
+Important: acquire is idempotent only by owner. If the same owner already holds
+the lock, another acquire returns `201` without changing the lock's
+`snapshot_version`. Use a fresh unique owner for each rollback attempt, or
+inspect namespace metadata before assuming the lock target changed.
+
+### `POST /nslock/release`
+
+| Status | Meaning |
+| --- | --- |
+| `200` | Rollback completed. |
+| `201` | Commit-mode release completed. |
+| `400` | Invalid owner. |
+| `404` | Namespace key was not found. |
+| `410` | Lock was lost during rollback. |
+| `422` | Namespace is not locked, or is locked by a different owner. |
+
+## Constraints and Caveats
+
+- The target should be a known committed/readable version and should not be
+  newer than the namespace head you intend to replace.
+- The target version must still be readable. If the namespace has a
+  `truncated_before` watermark newer than the target, normal reads at the
+  rolled-back head will be rejected.
+- Rollback moves one namespace head. It is not a multi-namespace atomic
+  rollback operation.
+- Rollback removes page-index entries and changelog entries newer than the
+  target version. Content blobs and content-index entries may remain until
+  storage cleanup runs.
+- To reclaim storage after rollback, run the admin
+  `delete_unreferenced_content` operation for the namespace.
+- If a rollback request fails due to a network or server interruption, inspect
+  `metadata.lock` with the admin `stat_namespace` endpoint before retrying or
+  starting another rollback.
+
+## Implementation Pointers
+
+- Data-plane routes: `mvstore/src/server.rs`, paths `/nslock/acquire` and
+  `/nslock/release`.
+- Rollback implementation: `mvstore/src/nslock.rs`, `release_nslock`.
+- Lock-aware stat behavior: `mvstore/src/stat.rs`.
+- Lock-aware commit behavior: `mvstore/src/commit.rs`.
+- Client lock-owner propagation: `mvclient/src/lib.rs`.
+- SQLite environment variable: `MVSQLITE_LOCK_OWNER` in `mvsqlite/src/lib.rs`.

--- a/mvstore/src/commit.rs
+++ b/mvstore/src/commit.rs
@@ -234,12 +234,57 @@ impl Server {
                                 });
                             }
 
+                            let effective_last_write_version =
+                                if actual_last_write_version == [0u8; 10] {
+                                    ns.ns_id
+                                } else {
+                                    actual_last_write_version
+                                };
+                            if ns.client_assumed_version > effective_last_write_version {
+                                tracing::warn!(
+                                    client_assumed_version =
+                                        hex::encode(&ns.client_assumed_version),
+                                    actual_last_write_version =
+                                        hex::encode(&actual_last_write_version),
+                                    "client assumed version is ahead of namespace head"
+                                );
+                                return Ok(CommitResult::Conflict);
+                            }
+
                             if ns.client_assumed_version < actual_last_write_version {
                                 if !plcc_enable_ns {
                                     return Ok(CommitResult::Conflict);
                                 }
                             }
                         }
+                    }
+                } else {
+                    // PLCC first attempts normally skip LWV to preserve page-level
+                    // concurrency. Still snapshot-read it to detect clients whose
+                    // assumed version is ahead of the namespace head after rollback.
+                    let actual_lwv_value = txn.get(&last_write_version_key, true).await?;
+                    let actual_last_write_version = actual_lwv_value
+                        .as_ref()
+                        .and_then(|t| {
+                            if t.len() == 16 + 10 {
+                                Some(<[u8; 10]>::try_from(&t[16..26]).unwrap())
+                            } else {
+                                None
+                            }
+                        })
+                        .unwrap_or_default();
+                    let effective_last_write_version = if actual_last_write_version == [0u8; 10] {
+                        ns.ns_id
+                    } else {
+                        actual_last_write_version
+                    };
+                    if ns.client_assumed_version > effective_last_write_version {
+                        tracing::warn!(
+                            client_assumed_version = hex::encode(&ns.client_assumed_version),
+                            actual_last_write_version = hex::encode(&actual_last_write_version),
+                            "client assumed version is ahead of namespace head"
+                        );
+                        return Ok(CommitResult::Conflict);
                     }
                 }
 

--- a/mvstore/src/commit.rs
+++ b/mvstore/src/commit.rs
@@ -262,6 +262,17 @@ impl Server {
                     // PLCC first attempts normally skip LWV to preserve page-level
                     // concurrency. Still snapshot-read it to detect clients whose
                     // assumed version is ahead of the namespace head after rollback.
+                    //
+                    // Snapshot is intentional here. This read is only a head-regression
+                    // sanity check, not PLCC's conflict mechanism. A non-snapshot LWV
+                    // read would make every PLCC first attempt conflict with any
+                    // concurrent writer in the namespace, effectively disabling PLCC.
+                    //
+                    // Rollback races are covered by the namespace metadata read above:
+                    // rollback marks `rolling_back` and later removes the lock by
+                    // writing ns metadata, while ns_metadata_cache.get adds that key to
+                    // this transaction's read conflict set. If rollback already lowered
+                    // LWV before this read version, this snapshot read observes it.
                     let actual_lwv_value = txn.get(&last_write_version_key, true).await?;
                     let actual_last_write_version = actual_lwv_value
                         .as_ref()

--- a/mvstore/src/gc.rs
+++ b/mvstore/src/gc.rs
@@ -29,28 +29,11 @@ impl Server {
         self: Arc<Self>,
         dry_run: bool,
         ns_id: [u8; 10],
-        mut before_version: [u8; 10],
+        before_version: [u8; 10],
         mut progress_callback: impl FnMut(Option<u64>),
     ) -> Result<()> {
-        // Fix up `before_version` to be the minimum of:
-        // - The supplied value
-        // - The cluster's current read version as seen by this snapshot
-        // - The NS lock version in the same snapshot
-        // - The minimum overlay snapshot_version from any namespace that
-        //   uses this namespace as its overlay base (fork safety)
-        {
-            let txn = self.db.create_trx()?;
-
-            before_version = before_version.min(get_txn_read_version_as_versionstamp(&txn).await?);
-
-            let metadata = self
-                .ns_metadata_cache
-                .get(&txn, &self.key_codec, ns_id)
-                .await?;
-            if let Some(lock) = &metadata.lock {
-                before_version = before_version.min(decode_version(&lock.snapshot_version)?);
-            }
-        }
+        let requested_before_version = before_version;
+        let before_version;
 
         let scan_start = self.key_codec.construct_page_key(ns_id, 0, [0u8; 10]);
         let scan_end = self
@@ -78,14 +61,16 @@ impl Server {
             anyhow::bail!("failed to acquire lock");
         }
 
-        // Clamp before_version to the minimum overlay child snapshot_version
-        // and write the truncated_before watermark, atomically in a single
-        // transaction.
+        // Clamp before_version to the minimum safe cutoff and write the
+        // truncated_before watermark, atomically in a single transaction.
         //
+        // This must be recomputed on every retry and in the same transaction
+        // that writes the watermark. A namespace lock acquired after this GC
+        // task starts must still clamp the cutoff before any pages are deleted.
         // The overlay_ref range is read with snapshot=false so it is added to
         // the read conflict set. If a concurrent create_namespace writes an
         // overlay_ref entry between our read and commit, this transaction
-        // conflicts and retries — we'll see the new child and clamp
+        // conflicts and retries, then sees the new child and clamps
         // accordingly. After this transaction commits, create_namespace will
         // see the watermark and reject forks at truncated versions.
         {
@@ -93,6 +78,24 @@ impl Server {
                 self.key_codec.construct_overlay_ref_range(ns_id);
             loop {
                 let txn = lock.create_txn_and_check_sync(&self.db).await?;
+                let mut effective_before_version =
+                    requested_before_version.min(get_txn_read_version_as_versionstamp(&txn).await?);
+
+                let metadata = match self
+                    .ns_metadata_cache
+                    .get(&txn, &self.key_codec, ns_id)
+                    .await
+                {
+                    Ok(m) => m,
+                    Err(e) => {
+                        txn.on_error(*e).await?;
+                        continue;
+                    }
+                };
+                if let Some(lock) = &metadata.lock {
+                    effective_before_version =
+                        effective_before_version.min(decode_version(&lock.snapshot_version)?);
+                }
 
                 // Non-snapshot read: adds overlay_ref range to conflict set.
                 let overlay_refs: Vec<_> = match txn
@@ -118,23 +121,12 @@ impl Server {
                 };
                 for kv in &overlay_refs {
                     if let Ok(v) = <[u8; 10]>::try_from(kv.value()) {
-                        before_version = before_version.min(v);
+                        effective_before_version = effective_before_version.min(v);
                     }
                 }
 
                 if !dry_run {
-                    let before_version_hex = hex::encode(before_version);
-                    let metadata = match self
-                        .ns_metadata_cache
-                        .get(&txn, &self.key_codec, ns_id)
-                        .await
-                    {
-                        Ok(m) => m,
-                        Err(e) => {
-                            txn.on_error(*e).await?;
-                            continue;
-                        }
-                    };
+                    let before_version_hex = hex::encode(effective_before_version);
                     let existing = metadata.truncated_before.as_deref().unwrap_or_default();
                     if before_version_hex.as_str() > existing {
                         let mut metadata = (*metadata).clone();
@@ -149,7 +141,10 @@ impl Server {
                 }
 
                 match txn.commit().await {
-                    Ok(_) => break,
+                    Ok(_) => {
+                        before_version = effective_before_version;
+                        break;
+                    }
                     Err(e) => {
                         e.on_error().await?;
                     }

--- a/mvstore/src/nslock.rs
+++ b/mvstore/src/nslock.rs
@@ -87,6 +87,15 @@ pub async fn acquire_nslock(
                 }
             }
 
+            if let Some(child_snapshot) = min_overlay_child_snapshot(&txn, key_codec, ns_id).await?
+            {
+                if requested_version < child_snapshot {
+                    return Ok(Response::builder().status(409).body(Body::from(
+                        "lock version is before an overlay child snapshot\n",
+                    ))?);
+                }
+            }
+
             requested_version
         } else {
             effective_head
@@ -183,29 +192,13 @@ pub async fn release_nslock(
                     // Existing overlay children depend on the base namespace at
                     // their snapshot versions. Rolling the base below any child
                     // snapshot would silently change child reads, so reject it.
-                    let (overlay_ref_start, overlay_ref_end) =
-                        key_codec.construct_overlay_ref_range(ns_id);
-                    let overlay_refs: Vec<_> = txn
-                        .get_ranges_keyvalues(
-                            RangeOption {
-                                limit: None,
-                                reverse: false,
-                                mode: StreamingMode::WantAll,
-                                ..RangeOption::from(
-                                    overlay_ref_start.as_slice()..=overlay_ref_end.as_slice(),
-                                )
-                            },
-                            false,
-                        )
-                        .try_collect()
-                        .await?;
-                    for child in &overlay_refs {
-                        if let Ok(child_snapshot) = <[u8; 10]>::try_from(child.value()) {
-                            if snapshot_version < child_snapshot {
-                                return Ok(Response::builder().status(409).body(Body::from(
-                                    "rollback is before an overlay child snapshot\n",
-                                ))?);
-                            }
+                    if let Some(child_snapshot) =
+                        min_overlay_child_snapshot(&txn, key_codec, ns_id).await?
+                    {
+                        if snapshot_version < child_snapshot {
+                            return Ok(Response::builder().status(409).body(Body::from(
+                                "rollback is before an overlay child snapshot\n",
+                            ))?);
                         }
                     }
 
@@ -350,6 +343,31 @@ pub async fn release_nslock(
     }
 
     Ok(Response::builder().status(200).body(Body::empty())?)
+}
+
+async fn min_overlay_child_snapshot(
+    txn: &Transaction,
+    key_codec: &KeyCodec,
+    ns_id: [u8; 10],
+) -> Result<Option<[u8; 10]>> {
+    let (overlay_ref_start, overlay_ref_end) = key_codec.construct_overlay_ref_range(ns_id);
+    let overlay_refs: Vec<_> = txn
+        .get_ranges_keyvalues(
+            RangeOption {
+                limit: None,
+                reverse: false,
+                mode: StreamingMode::WantAll,
+                ..RangeOption::from(overlay_ref_start.as_slice()..=overlay_ref_end.as_slice())
+            },
+            false,
+        )
+        .try_collect()
+        .await?;
+
+    Ok(overlay_refs
+        .iter()
+        .filter_map(|child| <[u8; 10]>::try_from(child.value()).ok())
+        .min())
 }
 
 async fn lock_is_still_valid(

--- a/mvstore/src/nslock.rs
+++ b/mvstore/src/nslock.rs
@@ -63,10 +63,33 @@ pub async fn acquire_nslock(
             }
         }
 
-        let snapshot_version = if let Some(version) = version {
-            decode_version(version)?
+        let current_lwv = get_last_write_version(&txn, key_codec, ns_id, false).await?;
+        let effective_head = if current_lwv == [0u8; 10] {
+            ns_id
         } else {
-            get_last_write_version(&txn, key_codec, ns_id, false).await?
+            current_lwv
+        };
+
+        let snapshot_version = if let Some(version) = version {
+            let requested_version = decode_version(version)?;
+            if requested_version > effective_head {
+                return Ok(Response::builder()
+                    .status(409)
+                    .body(Body::from("lock version is newer than namespace head\n"))?);
+            }
+
+            if let Some(truncated_before) = &metadata.truncated_before {
+                let truncated_before = decode_version(truncated_before)?;
+                if requested_version < truncated_before {
+                    return Ok(Response::builder()
+                        .status(409)
+                        .body(Body::from("lock version is before truncation watermark\n"))?);
+                }
+            }
+
+            requested_version
+        } else {
+            effective_head
         };
 
         let mut nonce: [u8; 16] = [0u8; 16];

--- a/mvstore/src/nslock.rs
+++ b/mvstore/src/nslock.rs
@@ -108,7 +108,7 @@ pub async fn release_nslock(
 
     let mut txn = db.create_trx()?;
     let nonce: String;
-    let snapshot_version: [u8; 10];
+    let mut snapshot_version: [u8; 10];
 
     loop {
         let metadata = ns_metadata_cache.get(&txn, key_codec, ns_id).await?;
@@ -149,6 +149,37 @@ pub async fn release_nslock(
             NslockReleaseMode::Rollback => {
                 // Rollback mode: first mark this lock as being rolled back.
                 if !lock.rolling_back {
+                    snapshot_version = decode_version(&lock.snapshot_version)?;
+
+                    // Existing overlay children depend on the base namespace at
+                    // their snapshot versions. Rolling the base below any child
+                    // snapshot would silently change child reads, so reject it.
+                    let (overlay_ref_start, overlay_ref_end) =
+                        key_codec.construct_overlay_ref_range(ns_id);
+                    let overlay_refs: Vec<_> = txn
+                        .get_ranges_keyvalues(
+                            RangeOption {
+                                limit: None,
+                                reverse: false,
+                                mode: StreamingMode::WantAll,
+                                ..RangeOption::from(
+                                    overlay_ref_start.as_slice()..=overlay_ref_end.as_slice(),
+                                )
+                            },
+                            false,
+                        )
+                        .try_collect()
+                        .await?;
+                    for child in &overlay_refs {
+                        if let Ok(child_snapshot) = <[u8; 10]>::try_from(child.value()) {
+                            if snapshot_version < child_snapshot {
+                                return Ok(Response::builder().status(409).body(Body::from(
+                                    "rollback is before an overlay child snapshot\n",
+                                ))?);
+                            }
+                        }
+                    }
+
                     lock.rolling_back = true;
                     let metadata = Arc::new(metadata);
                     ns_metadata_cache.set(&txn, key_codec, ns_id, metadata.clone())?;
@@ -158,9 +189,6 @@ pub async fn release_nslock(
                         Ok(output) => {
                             txn = output.reset();
                             nonce = metadata.lock.as_ref().unwrap().nonce.clone();
-                            snapshot_version = <[u8; 10]>::try_from(
-                                &hex::decode(&metadata.lock.as_ref().unwrap().snapshot_version)?[..],
-                            )?;
                             break;
                         }
                         Err(e) => {

--- a/mvstore/src/nslock.rs
+++ b/mvstore/src/nslock.rs
@@ -131,6 +131,12 @@ pub async fn release_nslock(
 
         match mode {
             NslockReleaseMode::Commit => {
+                if lock.rolling_back {
+                    return Ok(Response::builder()
+                        .status(409)
+                        .body(Body::from("rollback already in progress"))?);
+                }
+
                 // Commit mode: delete the lock and we're done.
                 metadata.lock = None;
                 ns_metadata_cache.set(&txn, key_codec, ns_id, Arc::new(metadata))?;
@@ -196,6 +202,10 @@ pub async fn release_nslock(
                             continue;
                         }
                     }
+                } else {
+                    nonce = lock.nonce.clone();
+                    snapshot_version = decode_version(&lock.snapshot_version)?;
+                    break;
                 }
             }
         }
@@ -203,7 +213,7 @@ pub async fn release_nslock(
 
     // We get here when rollback is required
     // Scan and delete
-    let mut total_count = 0u64;
+    let mut _total_count = 0u64;
 
     // Snapshot read is correct here - running through a range twice is fine
     let mut rollback_cursor = u32::from_le_bytes(
@@ -266,7 +276,7 @@ pub async fn release_nslock(
         match txn.commit().await {
             Ok(output) => {
                 txn = output.reset();
-                total_count += delete_count as u64;
+                _total_count += delete_count as u64;
                 rollback_cursor = new_rollback_cursor;
                 scan_cursor = FixedKeyVec::from_slice(&last_key).unwrap();
                 scan_cursor.push(0).unwrap();

--- a/mvstore/src/server.rs
+++ b/mvstore/src/server.rs
@@ -63,6 +63,7 @@ enum GetError {
 enum CreateNamespaceError {
     AlreadyExist,
     BaseTruncated,
+    BaseLocked,
 }
 
 impl std::fmt::Display for CreateNamespaceError {
@@ -316,6 +317,9 @@ impl Server {
                         return Err(anyhow::Error::new(CreateNamespaceError::BaseTruncated));
                     }
                 }
+                if base_metadata.lock.is_some() {
+                    return Err(anyhow::Error::new(CreateNamespaceError::BaseLocked));
+                }
             }
 
             let nsmd_atomic_op_key = generate_suffix_versionstamp_atomic_op(
@@ -387,6 +391,11 @@ impl Server {
                             return Ok(Response::builder().status(409).body(Body::from(
                                 "base namespace has been truncated past the requested snapshot_version\n",
                             ))?);
+                        }
+                        Some(CreateNamespaceError::BaseLocked) => {
+                            return Ok(Response::builder()
+                                .status(409)
+                                .body(Body::from("base namespace is locked\n"))?);
                         }
                         _ => {
                             return Ok(Response::builder()


### PR DESCRIPTION
This PR fixes several correctness issues in namespace rollback and nslock interactions with other mvstore subsystems.

Changes:

- Reject commits whose assumed version is ahead of the current namespace head, preventing stale pre-rollback transactions from committing after a rollback.
- Recompute truncate_versions cutoff inside the committed/retried watermark transaction, so newly acquired nslocks are honored by GC.
- Protect overlay/fork correctness by rejecting rollback below existing overlay child snapshots and rejecting overlay creation while the base namespace is locked.
- Make rollback release resumable when rolling_back=true.
- Reject commit-mode lock release after rollback has already started, preventing partially rolled-back state from being exposed.
- Add docs/rollback.md describing how to roll a namespace back using the data-plane nslock API.