### PR TITLE
Fix seen_hashes tracking for overlay child transactions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1299,7 +1299,7 @@ dependencies = [
 
 [[package]]
 name = "mvclient"
-version = "0.3.18"
+version = "0.3.19"
 dependencies = [
  "anyhow",
  "blake3",
@@ -1324,7 +1324,7 @@ dependencies = [
 
 [[package]]
 name = "mvfs"
-version = "0.3.18"
+version = "0.3.19"
 dependencies = [
  "anyhow",
  "bytes",
@@ -1342,7 +1342,7 @@ dependencies = [
 
 [[package]]
 name = "mvsqlite"
-version = "0.3.18"
+version = "0.3.19"
 dependencies = [
  "anyhow",
  "backtrace",
@@ -1365,7 +1365,7 @@ dependencies = [
 
 [[package]]
 name = "mvsqlite-fuse"
-version = "0.3.18"
+version = "0.3.19"
 dependencies = [
  "anyhow",
  "backtrace",
@@ -1391,7 +1391,7 @@ dependencies = [
 
 [[package]]
 name = "mvstore"
-version = "0.3.18"
+version = "0.3.19"
 dependencies = [
  "anyhow",
  "blake3",
@@ -1425,7 +1425,7 @@ dependencies = [
 
 [[package]]
 name = "mvstore-stress"
-version = "0.3.18"
+version = "0.3.19"
 dependencies = [
  "anyhow",
  "backtrace",

--- a/mvclient/Cargo.toml
+++ b/mvclient/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mvclient"
-version = "0.3.18"
+version = "0.3.19"
 edition = "2021"
 license = "Apache-2.0"
 authors = ["Heyang Zhou <heyang.zhou@icloud.com>"]

--- a/mvclient/src/lib.rs
+++ b/mvclient/src/lib.rs
@@ -361,6 +361,18 @@ pub struct Transaction {
     version: String,
     page_buffer: HashMap<u32, [u8; 32]>,
     async_ctx: Arc<TxnAsyncCtx>,
+    // Invariant: every hash in `seen_hashes` is a hash whose content this
+    // transaction has uploaded (or has scheduled to upload) to the current
+    // namespace's contentindex via `/batch/write`. `write_many` uses this set
+    // to skip re-uploading a page whose bytes it has already sent in this txn.
+    //
+    // Do NOT populate this set from `/batch/read` responses. On an overlay
+    // child, the read path falls back to the base namespace and returns bytes
+    // from `contentindex(base_ns_id, h)`; no entry for `contentindex(child_ns_id, h)`
+    // exists. If such a hash were added here, a subsequent `write_many` of the
+    // same bytes would be suppressed, `/batch/commit` would reference `h` under
+    // the child ns_id, and the server's Phase 1 lookup in `mvstore/src/commit.rs`
+    // would return `BadPageReference` (HTTP 410 "bad page reference").
     seen_hashes: Mutex<HashSet<[u8; 32]>>,
     read_only: bool,
     read_set: Option<Mutex<HashSet<u32>>>,
@@ -488,10 +500,12 @@ impl Transaction {
                     data.data.to_vec()
                 };
                 out.push(payload);
-                self.seen_hashes
-                    .lock()
-                    .unwrap()
-                    .insert(*blake3::hash(&data.data).as_bytes());
+                // Intentionally do not insert into `seen_hashes` here.
+                // For an overlay child, the server may satisfy this read from
+                // the base namespace's contentindex, so the returned hash is
+                // not owned by the child and would wrongly suppress a later
+                // `write_many` of the same bytes, causing commit to 410 with
+                // `BadPageReference`. See the comment on `Transaction::seen_hashes`.
             }
 
             if out.len() != page_id_list.len() {

--- a/mvfs/Cargo.toml
+++ b/mvfs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mvfs"
-version = "0.3.18"
+version = "0.3.19"
 edition = "2021"
 license = "Apache-2.0"
 authors = ["Heyang Zhou <heyang.zhou@icloud.com>"]
@@ -15,7 +15,7 @@ anyhow = "1"
 thiserror = "2"
 futures = "0.3"
 tokio = { version = "1", features = ["full"] }
-mvclient = { path = "../mvclient", version = "0.3.18" }
+mvclient = { path = "../mvclient", version = "0.3.19" }
 tracing = "0.1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/mvsqlite-fuse/Cargo.toml
+++ b/mvsqlite-fuse/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mvsqlite-fuse"
-version = "0.3.18"
+version = "0.3.19"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
@@ -11,7 +11,7 @@ thiserror = "2"
 tokio = { version = "1", features = ["full"] }
 log = "0.4"
 rand = "0.9"
-mvclient = { path = "../mvclient", version = "0.3.18" }
+mvclient = { path = "../mvclient", version = "0.3.19" }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3.16", features = ["env-filter", "fmt", "tracing-log", "json"] }
 libc = "0.2"
@@ -20,7 +20,7 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 lazy_static = "1.4.0"
 reqwest = { version = "0.12", default-features = false, features = ["rustls-tls"] }
-mvfs = { path = "../mvfs", version = "0.3.18" }
+mvfs = { path = "../mvfs", version = "0.3.19" }
 fuser = "0.14"
 structopt = "0.3.26"
 indexmap = "2"

--- a/mvsqlite/Cargo.toml
+++ b/mvsqlite/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mvsqlite"
-version = "0.3.18"
+version = "0.3.19"
 edition = "2021"
 license = "Apache-2.0"
 authors = ["Heyang Zhou <heyang.zhou@icloud.com>"]
@@ -17,7 +17,7 @@ tokio = { version = "1", features = ["full"] }
 log = "0.4"
 rand = "0.9"
 stackful = "0.1.5"
-mvclient = { path = "../mvclient", version = "0.3.18" }
+mvclient = { path = "../mvclient", version = "0.3.19" }
 tracing = "0.1"
 ctor = "0.2"
 tracing-subscriber = { version = "0.3.16", features = ["env-filter", "fmt", "json"], optional = true }
@@ -27,7 +27,7 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 lazy_static = "1.4.0"
 reqwest = { version = "0.12", default-features = false, features = ["http2"] }
-mvfs = { path = "../mvfs", version = "0.3.18" }
+mvfs = { path = "../mvfs", version = "0.3.19" }
 
 [features]
 default = ["loadext", "syscall", "rustls-tls", "global-init"]

--- a/mvstore-stress/Cargo.toml
+++ b/mvstore-stress/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "mvstore-stress"
-version = "0.3.18"
+version = "0.3.19"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-mvclient = { path = "../mvclient", version = "0.3.18" }
+mvclient = { path = "../mvclient", version = "0.3.19" }
 anyhow = "1"
 thiserror = "2"
 tokio = { version = "1", features = ["full"] }

--- a/mvstore/Cargo.toml
+++ b/mvstore/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mvstore"
-version = "0.3.18"
+version = "0.3.19"
 edition = "2021"
 license = "Apache-2.0"
 authors = ["Heyang Zhou <heyang.zhou@icloud.com>"]


### PR DESCRIPTION
## Summary
This change fixes a critical bug in transaction handling for overlay child namespaces where hashes from `/batch/read` responses were incorrectly being added to `seen_hashes`, causing subsequent writes of the same bytes to be suppressed and resulting in `BadPageReference` (HTTP 410) errors during commit.

## Key Changes
- **Added comprehensive documentation** to the `seen_hashes` field explaining its invariant: it should only contain hashes of content that has been uploaded (or scheduled for upload) to the current namespace's contentindex via `/batch/write`
- **Removed hash insertion in read path**: Removed the code that was inserting hashes from `/batch/read` responses into `seen_hashes`
- **Added detailed comment** explaining why hashes from reads must not be tracked, particularly for overlay children where reads may be satisfied from the base namespace's contentindex

## Implementation Details
The bug occurred because on overlay child namespaces, the read path can fall back to the base namespace and return bytes from `contentindex(base_ns_id, h)`. If such a hash were added to `seen_hashes`, a subsequent `write_many` of the same bytes would be incorrectly suppressed. This would cause `/batch/commit` to reference the hash under the child namespace ID, but the server's Phase 1 lookup would fail because the hash only exists in the base namespace, resulting in a `BadPageReference` error.

The fix ensures that `seen_hashes` is only populated from writes, not reads, preventing this namespace mismatch scenario.

## Version Bump
All workspace crates have been bumped from version 0.3.18 to 0.3.19.

https://claude.ai/code/session_01RBaE5jq6fq1fV4DdzxJSGB