### PR TITLE
Add SQL functions for namespace lock acquire/release

### DIFF
--- a/docs/nslock.md
+++ b/docs/nslock.md
@@ -129,6 +129,13 @@ owner to one connection, or roll back without restarting.
 The acquire/release SQL functions error out if a SQLite transaction is
 currently open on the connection.
 
+**Idempotent re-acquire.** Calling `mv_nslock_acquire` with the same `owner`
+while the lock is already held returns success without changing
+`snapshot_version`. If you need to roll back to a different point, release
+the existing lock first (or use a fresh `owner`) — passing a `version`
+argument while you already hold the lock is **silently ignored** by the
+server.
+
 ## API Reference
 
 ### Acquire Lock

--- a/docs/nslock.md
+++ b/docs/nslock.md
@@ -83,16 +83,51 @@ Implementation: `mvstore/src/nslock.rs` (`release_nslock`).
 
 ## Client-Side Configuration
 
+There are two ways to surface the lock owner to the mvclient.
+
+### 1. Environment variable (process-wide default)
+
 The SQLite VFS layer (`mvsqlite/src/lib.rs`) reads the lock owner from the environment:
 
 ```bash
 export MVSQLITE_LOCK_OWNER="my-unique-client-id"
 ```
 
-When set, the mvclient automatically:
+When set, every `MultiVersionClient` produced by the VFS starts with this
+value as its effective lock owner. The mvclient automatically:
 
 - Appends `lock_owner=...` to `/stat` requests.
 - Includes `lock_owner` in `CommitGlobalInit` during batch commit.
+
+### 2. SQL functions (per-connection)
+
+mvsqlite registers three SQL functions on every connection (see
+`mvsqlite/src/lib.rs`, `init_mvsqlite_connection`):
+
+```sql
+SELECT mv_nslock_acquire('main', 'worker-1');                 -- live LWV
+SELECT mv_nslock_acquire('main', 'worker-1', '<version-hex>'); -- explicit version
+
+SELECT mv_nslock_release_commit('main', 'worker-1');
+SELECT mv_nslock_release_rollback('main', 'worker-1');
+```
+
+The first argument is the attached schema name (`'main'` for the default
+database). All three are `SQLITE_DIRECTONLY` and return `NULL` on success or
+a SQL error on failure.
+
+A successful `mv_nslock_acquire` updates the **calling connection's**
+effective lock owner; subsequent `/stat` and `/batch/commit` requests issued
+by that connection carry the new `lock_owner`. A successful release clears
+it. The change is scoped to the single mvclient instance backing that
+connection and does not affect sibling connections sharing the same VFS.
+
+Both the env-var and SQL paths share the same wire protocol; the SQL path is
+preferred when a process needs to acquire the lock at runtime, scope the
+owner to one connection, or roll back without restarting.
+
+The acquire/release SQL functions error out if a SQLite transaction is
+currently open on the connection.
 
 ## API Reference
 
@@ -138,6 +173,8 @@ Content-Type: application/json
 
 ## Typical Usage Pattern
 
+### Via HTTP
+
 ```
 1. POST /nslock/acquire?ns=XX  {"owner": "worker-1"}
 2. Run SQLite operations with MVSQLITE_LOCK_OWNER=worker-1
@@ -145,4 +182,14 @@ Content-Type: application/json
 3a. On success: POST /nslock/release?ns=XX  {"owner": "worker-1", "mode": "commit"}
 3b. On failure: POST /nslock/release?ns=XX  {"owner": "worker-1", "mode": "rollback"}
    (all writes since acquire are erased)
+```
+
+### Via SQL
+
+```sql
+SELECT mv_nslock_acquire('main', 'worker-1');
+-- ... do work; subsequent commits on this connection carry lock_owner=worker-1
+SELECT mv_nslock_release_commit('main', 'worker-1');
+-- or, to discard everything written since acquire:
+SELECT mv_nslock_release_rollback('main', 'worker-1');
 ```

--- a/mvclient/src/lib.rs
+++ b/mvclient/src/lib.rs
@@ -234,6 +234,12 @@ impl MultiVersionClient {
 
     /// Override the effective lock owner. Subsequent `/stat` and
     /// `/batch/commit` requests will carry this value. Pass `None` to clear.
+    ///
+    /// Note: mvfs constructs a fresh `MultiVersionClient` per `open()` and
+    /// treats this owner as per-connection state. If a caller shares one
+    /// `MultiVersionClient` across multiple logical connections, mutating
+    /// the owner here affects all of them — that is generally not what
+    /// SQL-driven `mv_nslock_acquire`/`release` expects.
     pub fn set_lock_owner(&self, owner: Option<String>) {
         *self.lock_owner.write().unwrap() = owner;
     }
@@ -431,17 +437,21 @@ impl MultiVersionClient {
                 Err((status, headers, body)) => {
                     return Ok(match status.as_u16() {
                         400 => NslockAcquireOutcome::InvalidOwner,
-                        409 => {
-                            let lock_owner = headers
-                                .get("x-lock-owner")
-                                .and_then(|v| v.to_str().ok())
-                                .map(|s| s.to_string());
-                            if lock_owner.is_some() {
-                                NslockAcquireOutcome::HeldByOther(lock_owner)
-                            } else {
-                                NslockAcquireOutcome::Rejected(status, body)
-                            }
-                        }
+                        // The server returns 409 for two distinct cases:
+                        //   (a) namespace already locked by a different owner —
+                        //       includes the `x-lock-owner` response header.
+                        //   (b) requested explicit version is unsuitable
+                        //       (newer than head, before truncation watermark,
+                        //       or before an overlay child snapshot) — no
+                        //       `x-lock-owner` header, body explains why.
+                        // Discriminate by header presence; fall back to a
+                        // generic Rejected so the body reaches the caller.
+                        409 => match headers.get("x-lock-owner") {
+                            Some(v) => NslockAcquireOutcome::HeldByOther(
+                                v.to_str().ok().map(|s| s.to_string()),
+                            ),
+                            None => NslockAcquireOutcome::Rejected(status, body),
+                        },
                         _ => NslockAcquireOutcome::Rejected(status, body),
                     });
                 }
@@ -487,7 +497,19 @@ impl MultiVersionClient {
                 Err((status, headers, body)) => {
                     return Ok(match status.as_u16() {
                         400 => NslockReleaseOutcome::InvalidOwner,
-                        409 => NslockReleaseOutcome::RollbackInProgress,
+                        // 409 only means "rollback already in progress" for
+                        // a Commit-mode release. For Rollback mode the server
+                        // also returns 409 when the rollback target predates
+                        // an overlay child snapshot — that is a distinct
+                        // condition and should surface verbatim.
+                        409 => match mode {
+                            NslockReleaseMode::Commit => {
+                                NslockReleaseOutcome::RollbackInProgress
+                            }
+                            NslockReleaseMode::Rollback => {
+                                NslockReleaseOutcome::Rejected(status, body)
+                            }
+                        },
                         410 => NslockReleaseOutcome::LockGone,
                         422 => {
                             let lock_owner = headers

--- a/mvclient/src/lib.rs
+++ b/mvclient/src/lib.rs
@@ -14,7 +14,7 @@ use std::{
     collections::{HashMap, HashSet},
     sync::{
         atomic::{AtomicBool, Ordering},
-        Arc, Mutex,
+        Arc, Mutex, RwLock,
     },
     time::{Duration, Instant},
 };
@@ -30,6 +30,11 @@ pub enum CommitError {
 pub struct MultiVersionClient {
     client: reqwest::Client,
     config: MultiVersionClientConfig,
+    /// Effective lock owner. Initialized from `config.lock_owner` and can be
+    /// updated at runtime via `set_lock_owner`. Read on every `/stat` and
+    /// `/batch/commit` request so SQL-driven `mv_nslock_acquire`/`release`
+    /// can change which `lock_owner` is sent.
+    lock_owner: RwLock<Option<String>>,
 }
 
 #[derive(Clone, Debug)]
@@ -42,6 +47,8 @@ pub struct MultiVersionClientConfig {
 
     pub ns_key_hashproof: Option<String>,
 
+    /// Initial value for the client's effective lock owner. May be overridden
+    /// at runtime via `MultiVersionClient::set_lock_owner`.
     pub lock_owner: Option<String>,
 }
 
@@ -162,13 +169,73 @@ pub struct TimeToVersionPoint {
     pub time: u64,
 }
 
+#[derive(Copy, Clone, Debug)]
+pub enum NslockReleaseMode {
+    Commit,
+    Rollback,
+}
+
+impl NslockReleaseMode {
+    fn as_str(self) -> &'static str {
+        match self {
+            NslockReleaseMode::Commit => "commit",
+            NslockReleaseMode::Rollback => "rollback",
+        }
+    }
+}
+
+#[derive(Debug)]
+pub enum NslockAcquireOutcome {
+    /// Lock acquired (or already owned by the same owner).
+    Acquired,
+    /// Held by a different owner. The string is the current owner, if reported.
+    HeldByOther(Option<String>),
+    /// Owner string was rejected (empty or > 256 bytes).
+    InvalidOwner,
+    /// Other client error: e.g., requested version is older than the
+    /// truncation watermark or newer than the namespace head.
+    Rejected(StatusCode, String),
+}
+
+#[derive(Debug)]
+pub enum NslockReleaseOutcome {
+    /// Commit-mode release succeeded, or rollback completed.
+    Released,
+    /// Lock disappeared during a rollback (nonce mismatch).
+    LockGone,
+    /// Namespace was not locked, or was locked by a different owner.
+    OwnerMismatch(Option<String>),
+    /// Rollback was already in progress and a Commit-mode release was issued.
+    RollbackInProgress,
+    /// Owner string was rejected.
+    InvalidOwner,
+    /// Other client error.
+    Rejected(StatusCode, String),
+}
+
 impl MultiVersionClient {
     pub fn new(config: MultiVersionClientConfig, client: reqwest::Client) -> Result<Arc<Self>> {
-        Ok(Arc::new(Self { client, config }))
+        let lock_owner = RwLock::new(config.lock_owner.clone());
+        Ok(Arc::new(Self {
+            client,
+            config,
+            lock_owner,
+        }))
     }
 
     pub fn config(&self) -> &MultiVersionClientConfig {
         &self.config
+    }
+
+    /// Returns the currently effective lock owner, if any.
+    pub fn lock_owner(&self) -> Option<String> {
+        self.lock_owner.read().unwrap().clone()
+    }
+
+    /// Override the effective lock owner. Subsequent `/stat` and
+    /// `/batch/commit` requests will carry this value. Pass `None` to clear.
+    pub fn set_lock_owner(&self, owner: Option<String>) {
+        *self.lock_owner.write().unwrap() = owner;
     }
 
     pub async fn create_transaction(self: &Arc<Self>, dp: Option<&Url>) -> Result<Transaction> {
@@ -192,8 +259,8 @@ impl MultiVersionClient {
                 .append_pair("from_version", from_version);
         }
 
-        if let Some(lock_owner) = &self.config.lock_owner {
-            url.query_pairs_mut().append_pair("lock_owner", lock_owner);
+        if let Some(lock_owner) = self.lock_owner() {
+            url.query_pairs_mut().append_pair("lock_owner", &lock_owner);
         }
 
         let mut boff = RandomizedExponentialBackoff::default();
@@ -268,11 +335,12 @@ impl MultiVersionClient {
         let mut allow_skip_idempotency_check = true; // only for the first attempt
 
         loop {
+            let lock_owner = self.lock_owner();
             let global_init = CommitGlobalInit {
                 idempotency_key: &idempotency_key[..],
                 allow_skip_idempotency_check,
                 num_namespaces: intents.len(),
-                lock_owner: self.config.lock_owner.as_deref(),
+                lock_owner: lock_owner.as_deref(),
             };
             allow_skip_idempotency_check = false;
             let mut raw_request: Vec<u8> = Vec::new();
@@ -324,6 +392,114 @@ impl MultiVersionClient {
                 num_pages: total_num_pages as u64,
                 changelog: body.changelog,
             }));
+        }
+    }
+
+    pub async fn nslock_acquire(
+        &self,
+        dp: Option<&Url>,
+        owner: &str,
+        version: Option<&str>,
+    ) -> Result<NslockAcquireOutcome> {
+        #[derive(Serialize)]
+        struct Body<'a> {
+            owner: &'a str,
+            #[serde(skip_serializing_if = "Option::is_none")]
+            version: Option<&'a str>,
+        }
+
+        let mut url = dp
+            .unwrap_or_else(|| self.config.random_data_plane())
+            .clone();
+        url.set_path("/nslock/acquire");
+        let body = serde_json::to_vec(&Body { owner, version })?;
+
+        let mut boff = RandomizedExponentialBackoff::default();
+        loop {
+            let req = self
+                .client
+                .post(url.clone())
+                .header("content-type", "application/json")
+                .body(body.clone())
+                .decorate(self);
+            match request_and_check_returning_status_with_response(req).await {
+                Ok(Some(_)) => return Ok(NslockAcquireOutcome::Acquired),
+                Ok(None) => {
+                    boff.wait().await;
+                    continue;
+                }
+                Err((status, headers, body)) => {
+                    return Ok(match status.as_u16() {
+                        400 => NslockAcquireOutcome::InvalidOwner,
+                        409 => {
+                            let lock_owner = headers
+                                .get("x-lock-owner")
+                                .and_then(|v| v.to_str().ok())
+                                .map(|s| s.to_string());
+                            if lock_owner.is_some() {
+                                NslockAcquireOutcome::HeldByOther(lock_owner)
+                            } else {
+                                NslockAcquireOutcome::Rejected(status, body)
+                            }
+                        }
+                        _ => NslockAcquireOutcome::Rejected(status, body),
+                    });
+                }
+            }
+        }
+    }
+
+    pub async fn nslock_release(
+        &self,
+        dp: Option<&Url>,
+        owner: &str,
+        mode: NslockReleaseMode,
+    ) -> Result<NslockReleaseOutcome> {
+        #[derive(Serialize)]
+        struct Body<'a> {
+            owner: &'a str,
+            mode: &'a str,
+        }
+
+        let mut url = dp
+            .unwrap_or_else(|| self.config.random_data_plane())
+            .clone();
+        url.set_path("/nslock/release");
+        let body = serde_json::to_vec(&Body {
+            owner,
+            mode: mode.as_str(),
+        })?;
+
+        let mut boff = RandomizedExponentialBackoff::default();
+        loop {
+            let req = self
+                .client
+                .post(url.clone())
+                .header("content-type", "application/json")
+                .body(body.clone())
+                .decorate(self);
+            match request_and_check_returning_status_with_response(req).await {
+                Ok(Some(_)) => return Ok(NslockReleaseOutcome::Released),
+                Ok(None) => {
+                    boff.wait().await;
+                    continue;
+                }
+                Err((status, headers, body)) => {
+                    return Ok(match status.as_u16() {
+                        400 => NslockReleaseOutcome::InvalidOwner,
+                        409 => NslockReleaseOutcome::RollbackInProgress,
+                        410 => NslockReleaseOutcome::LockGone,
+                        422 => {
+                            let lock_owner = headers
+                                .get("x-lock-owner")
+                                .and_then(|v| v.to_str().ok())
+                                .map(|s| s.to_string());
+                            NslockReleaseOutcome::OwnerMismatch(lock_owner)
+                        }
+                        _ => NslockReleaseOutcome::Rejected(status, body),
+                    });
+                }
+            }
         }
     }
 
@@ -761,6 +937,42 @@ async fn request_and_check_returning_status(
         let text = res.text().await.unwrap_or_default();
         tracing::warn!(status = %status, text = %text, "client error");
         Err(status)
+    }
+}
+
+/// Variant of `request_and_check_returning_status` that retains response
+/// headers and body on 4xx so callers can inspect things like `x-lock-owner`.
+async fn request_and_check_returning_status_with_response(
+    r: RequestBuilder,
+) -> Result<Option<(HeaderMap, Bytes)>, (StatusCode, HeaderMap, String)> {
+    let res = match r.send().await {
+        Ok(x) => x,
+        Err(e) => {
+            tracing::error!(error = %e, "network error");
+            return Ok(None);
+        }
+    };
+    if res.status().is_success() {
+        let headers = res.headers().clone();
+        let body = match res.bytes().await {
+            Ok(x) => x,
+            Err(e) => {
+                tracing::error!(error = %e, "failed to read response body");
+                return Ok(None);
+            }
+        };
+        Ok(Some((headers, body)))
+    } else if res.status().is_server_error() {
+        let status = res.status();
+        let text = res.text().await.unwrap_or_default();
+        tracing::error!(status = %status, text = text, "server error");
+        Ok(None)
+    } else {
+        let status = res.status();
+        let headers = res.headers().clone();
+        let text = res.text().await.unwrap_or_default();
+        tracing::warn!(status = %status, text = %text, "client error");
+        Err((status, headers, text))
     }
 }
 

--- a/mvfs/src/vfs.rs
+++ b/mvfs/src/vfs.rs
@@ -12,8 +12,8 @@ use std::{
 };
 
 use mvclient::{
-    CommitOutput, MultiVersionClient, MultiVersionClientConfig, StatusCodeError,
-    TimeToVersionResponse, Transaction,
+    CommitOutput, MultiVersionClient, MultiVersionClientConfig, NslockAcquireOutcome,
+    NslockReleaseMode, NslockReleaseOutcome, StatusCodeError, TimeToVersionResponse, Transaction,
 };
 
 use crate::{
@@ -350,6 +350,95 @@ impl Connection {
 
         self.fixed_version = None;
         Ok(())
+    }
+
+    /// Acquire a namespace lock with `owner`. On success, sets the
+    /// connection's effective lock owner so subsequent stat/commit requests
+    /// carry it.
+    pub async fn nslock_acquire(
+        &mut self,
+        owner: String,
+        version: Option<String>,
+    ) -> Result<()> {
+        if self.txn.is_some() {
+            anyhow::bail!("cannot acquire nslock while a transaction is active");
+        }
+        let outcome = self
+            .client
+            .nslock_acquire(self.dp.as_ref(), &owner, version.as_deref())
+            .await?;
+        match outcome {
+            NslockAcquireOutcome::Acquired => {
+                self.client.set_lock_owner(Some(owner));
+                Ok(())
+            }
+            NslockAcquireOutcome::HeldByOther(other) => {
+                anyhow::bail!(
+                    "nslock: held by other owner{}",
+                    other
+                        .as_deref()
+                        .map(|o| format!(": {}", o))
+                        .unwrap_or_default()
+                );
+            }
+            NslockAcquireOutcome::InvalidOwner => {
+                anyhow::bail!("nslock: invalid owner (empty or > 256 bytes)");
+            }
+            NslockAcquireOutcome::Rejected(status, body) => {
+                anyhow::bail!("nslock: server rejected acquire (status {}): {}", status, body);
+            }
+        }
+    }
+
+    /// Release a namespace lock, optionally rolling back. Clears the
+    /// connection's effective lock owner on success.
+    pub async fn nslock_release(
+        &mut self,
+        owner: String,
+        mode: NslockReleaseMode,
+    ) -> Result<()> {
+        if self.txn.is_some() {
+            anyhow::bail!("cannot release nslock while a transaction is active");
+        }
+        let outcome = self
+            .client
+            .nslock_release(self.dp.as_ref(), &owner, mode)
+            .await?;
+        match outcome {
+            NslockReleaseOutcome::Released => {
+                if self
+                    .client
+                    .lock_owner()
+                    .as_deref()
+                    .map(|o| o == owner)
+                    .unwrap_or(false)
+                {
+                    self.client.set_lock_owner(None);
+                }
+                Ok(())
+            }
+            NslockReleaseOutcome::LockGone => {
+                anyhow::bail!("nslock: lock is gone (nonce mismatch during rollback)");
+            }
+            NslockReleaseOutcome::OwnerMismatch(other) => {
+                anyhow::bail!(
+                    "nslock: not locked or owner mismatch{}",
+                    other
+                        .as_deref()
+                        .map(|o| format!(" (current: {})", o))
+                        .unwrap_or_default()
+                );
+            }
+            NslockReleaseOutcome::RollbackInProgress => {
+                anyhow::bail!("nslock: rollback already in progress");
+            }
+            NslockReleaseOutcome::InvalidOwner => {
+                anyhow::bail!("nslock: invalid owner");
+            }
+            NslockReleaseOutcome::Rejected(status, body) => {
+                anyhow::bail!("nslock: server rejected release (status {}): {}", status, body);
+            }
+        }
     }
 
     async fn finalize_transaction(&mut self, commit: bool) -> bool {

--- a/mvfs/src/vfs.rs
+++ b/mvfs/src/vfs.rs
@@ -406,15 +406,11 @@ impl Connection {
             .await?;
         match outcome {
             NslockReleaseOutcome::Released => {
-                if self
-                    .client
-                    .lock_owner()
-                    .as_deref()
-                    .map(|o| o == owner)
-                    .unwrap_or(false)
-                {
-                    self.client.set_lock_owner(None);
-                }
+                // The server confirmed `owner` held the lock and removed it
+                // (commit-mode) or finished the rollback. Clear the effective
+                // lock owner unconditionally so subsequent commits on this
+                // connection do not carry a stale `lock_owner`.
+                self.client.set_lock_owner(None);
                 Ok(())
             }
             NslockReleaseOutcome::LockGone => {

--- a/mvsqlite/src/lib.rs
+++ b/mvsqlite/src/lib.rs
@@ -568,16 +568,26 @@ unsafe extern "C" fn mv_prefetch_metrics(
     );
 }
 
-unsafe fn read_text_arg(value: *mut sqlite_c::sqlite3_value) -> Option<String> {
+/// Reads a SQL text argument as a UTF-8 owned String.
+///
+/// Returns:
+/// - `Ok(None)` if the SQL value is NULL.
+/// - `Ok(Some(s))` for valid UTF-8 text.
+/// - `Err(())` if the bytes are not valid UTF-8. Owner strings flow into
+///   `nslock` where they act as a capability that gates rollback; silently
+///   replacing invalid bytes with U+FFFD would let a typo gate the wrong
+///   operation, so we reject instead.
+unsafe fn read_text_arg(
+    value: *mut sqlite_c::sqlite3_value,
+) -> std::result::Result<Option<String>, ()> {
     let p = sqlite_c::sqlite3_value_text(value);
     if p.is_null() {
-        return None;
+        return Ok(None);
     }
-    Some(
-        std::ffi::CStr::from_ptr(p as *const c_char)
-            .to_string_lossy()
-            .into_owned(),
-    )
+    std::ffi::CStr::from_ptr(p as *const c_char)
+        .to_str()
+        .map(|s| Some(s.to_string()))
+        .map_err(|_| ())
 }
 
 unsafe fn set_sqlite_error(ctx: *mut sqlite_c::sqlite3_context, msg: &str) {
@@ -592,21 +602,35 @@ unsafe extern "C" fn mv_nslock_acquire(
 ) {
     assert!(argc == 2 || argc == 3);
     let selected_db = match read_text_arg(*argv.add(0)) {
-        Some(x) => x,
-        None => {
+        Ok(Some(x)) => x,
+        Ok(None) => {
             set_sqlite_error(ctx, "mv_nslock_acquire: db argument is required");
+            return;
+        }
+        Err(()) => {
+            set_sqlite_error(ctx, "mv_nslock_acquire: db argument is not valid UTF-8");
             return;
         }
     };
     let owner = match read_text_arg(*argv.add(1)) {
-        Some(x) => x,
-        None => {
+        Ok(Some(x)) => x,
+        Ok(None) => {
             set_sqlite_error(ctx, "mv_nslock_acquire: owner argument is required");
+            return;
+        }
+        Err(()) => {
+            set_sqlite_error(ctx, "mv_nslock_acquire: owner argument is not valid UTF-8");
             return;
         }
     };
     let version = if argc == 3 {
-        read_text_arg(*argv.add(2))
+        match read_text_arg(*argv.add(2)) {
+            Ok(v) => v,
+            Err(()) => {
+                set_sqlite_error(ctx, "mv_nslock_acquire: version argument is not valid UTF-8");
+                return;
+            }
+        }
     } else {
         None
     };
@@ -644,16 +668,24 @@ unsafe fn nslock_release_impl(
 ) {
     assert_eq!(argc, 2);
     let selected_db = match read_text_arg(*argv.add(0)) {
-        Some(x) => x,
-        None => {
+        Ok(Some(x)) => x,
+        Ok(None) => {
             set_sqlite_error(ctx, "mv_nslock_release: db argument is required");
+            return;
+        }
+        Err(()) => {
+            set_sqlite_error(ctx, "mv_nslock_release: db argument is not valid UTF-8");
             return;
         }
     };
     let owner = match read_text_arg(*argv.add(1)) {
-        Some(x) => x,
-        None => {
+        Ok(Some(x)) => x,
+        Ok(None) => {
             set_sqlite_error(ctx, "mv_nslock_release: owner argument is required");
+            return;
+        }
+        Err(()) => {
+            set_sqlite_error(ctx, "mv_nslock_release: owner argument is not valid UTF-8");
             return;
         }
     };

--- a/mvsqlite/src/lib.rs
+++ b/mvsqlite/src/lib.rs
@@ -238,6 +238,9 @@ pub unsafe extern "C" fn init_mvsqlite_connection(db: *mut sqlite_c::sqlite3) {
     let mv_pin_version_name = b"mv_pin_version\0";
     let mv_unpin_version_name = b"mv_unpin_version\0";
     let mv_prefetch_metrics_name = b"mv_prefetch_metrics\0";
+    let mv_nslock_acquire_name = b"mv_nslock_acquire\0";
+    let mv_nslock_release_commit_name = b"mv_nslock_release_commit\0";
+    let mv_nslock_release_rollback_name = b"mv_nslock_release_rollback\0";
 
     let ret = sqlite_c::sqlite3_create_function_v2(
         db,
@@ -298,6 +301,58 @@ pub unsafe extern "C" fn init_mvsqlite_connection(db: *mut sqlite_c::sqlite3) {
         sqlite_c::SQLITE_UTF8 | sqlite_c::SQLITE_DIRECTONLY,
         std::ptr::null_mut(),
         Some(mv_prefetch_metrics),
+        None,
+        None,
+        None,
+    );
+    assert_eq!(ret, sqlite_c::SQLITE_OK);
+
+    let ret = sqlite_c::sqlite3_create_function_v2(
+        db,
+        mv_nslock_acquire_name.as_ptr() as *const c_char,
+        2,
+        sqlite_c::SQLITE_UTF8 | sqlite_c::SQLITE_DIRECTONLY,
+        std::ptr::null_mut(),
+        Some(mv_nslock_acquire),
+        None,
+        None,
+        None,
+    );
+    assert_eq!(ret, sqlite_c::SQLITE_OK);
+
+    let ret = sqlite_c::sqlite3_create_function_v2(
+        db,
+        mv_nslock_acquire_name.as_ptr() as *const c_char,
+        3,
+        sqlite_c::SQLITE_UTF8 | sqlite_c::SQLITE_DIRECTONLY,
+        std::ptr::null_mut(),
+        Some(mv_nslock_acquire),
+        None,
+        None,
+        None,
+    );
+    assert_eq!(ret, sqlite_c::SQLITE_OK);
+
+    let ret = sqlite_c::sqlite3_create_function_v2(
+        db,
+        mv_nslock_release_commit_name.as_ptr() as *const c_char,
+        2,
+        sqlite_c::SQLITE_UTF8 | sqlite_c::SQLITE_DIRECTONLY,
+        std::ptr::null_mut(),
+        Some(mv_nslock_release_commit),
+        None,
+        None,
+        None,
+    );
+    assert_eq!(ret, sqlite_c::SQLITE_OK);
+
+    let ret = sqlite_c::sqlite3_create_function_v2(
+        db,
+        mv_nslock_release_rollback_name.as_ptr() as *const c_char,
+        2,
+        sqlite_c::SQLITE_UTF8 | sqlite_c::SQLITE_DIRECTONLY,
+        std::ptr::null_mut(),
+        Some(mv_nslock_release_rollback),
         None,
         None,
         None,
@@ -511,6 +566,105 @@ unsafe extern "C" fn mv_prefetch_metrics(
         json.as_bytes().len() as i32,
         crate::sqlite_misc::SQLITE_TRANSIENT(),
     );
+}
+
+unsafe fn read_text_arg(value: *mut sqlite_c::sqlite3_value) -> Option<String> {
+    let p = sqlite_c::sqlite3_value_text(value);
+    if p.is_null() {
+        return None;
+    }
+    Some(
+        std::ffi::CStr::from_ptr(p as *const c_char)
+            .to_string_lossy()
+            .into_owned(),
+    )
+}
+
+unsafe fn set_sqlite_error(ctx: *mut sqlite_c::sqlite3_context, msg: &str) {
+    let error = CString::new(msg).unwrap_or_else(|_| CString::new("error").unwrap());
+    sqlite_c::sqlite3_result_error(ctx, error.as_ptr(), error.as_bytes().len() as i32);
+}
+
+unsafe extern "C" fn mv_nslock_acquire(
+    ctx: *mut sqlite_c::sqlite3_context,
+    argc: std::os::raw::c_int,
+    argv: *mut *mut sqlite_c::sqlite3_value,
+) {
+    assert!(argc == 2 || argc == 3);
+    let selected_db = match read_text_arg(*argv.add(0)) {
+        Some(x) => x,
+        None => {
+            set_sqlite_error(ctx, "mv_nslock_acquire: db argument is required");
+            return;
+        }
+    };
+    let owner = match read_text_arg(*argv.add(1)) {
+        Some(x) => x,
+        None => {
+            set_sqlite_error(ctx, "mv_nslock_acquire: owner argument is required");
+            return;
+        }
+    };
+    let version = if argc == 3 {
+        read_text_arg(*argv.add(2))
+    } else {
+        None
+    };
+
+    let db = sqlite_c::sqlite3_context_db_handle(ctx);
+    let mut conn = get_conn(db, &selected_db);
+    let io = conn.io.clone();
+    match io.run(conn.inner.nslock_acquire(owner, version)) {
+        Ok(()) => sqlite_c::sqlite3_result_null(ctx),
+        Err(e) => set_sqlite_error(ctx, &format!("{}", e)),
+    }
+}
+
+unsafe extern "C" fn mv_nslock_release_commit(
+    ctx: *mut sqlite_c::sqlite3_context,
+    argc: std::os::raw::c_int,
+    argv: *mut *mut sqlite_c::sqlite3_value,
+) {
+    nslock_release_impl(ctx, argc, argv, mvclient::NslockReleaseMode::Commit);
+}
+
+unsafe extern "C" fn mv_nslock_release_rollback(
+    ctx: *mut sqlite_c::sqlite3_context,
+    argc: std::os::raw::c_int,
+    argv: *mut *mut sqlite_c::sqlite3_value,
+) {
+    nslock_release_impl(ctx, argc, argv, mvclient::NslockReleaseMode::Rollback);
+}
+
+unsafe fn nslock_release_impl(
+    ctx: *mut sqlite_c::sqlite3_context,
+    argc: std::os::raw::c_int,
+    argv: *mut *mut sqlite_c::sqlite3_value,
+    mode: mvclient::NslockReleaseMode,
+) {
+    assert_eq!(argc, 2);
+    let selected_db = match read_text_arg(*argv.add(0)) {
+        Some(x) => x,
+        None => {
+            set_sqlite_error(ctx, "mv_nslock_release: db argument is required");
+            return;
+        }
+    };
+    let owner = match read_text_arg(*argv.add(1)) {
+        Some(x) => x,
+        None => {
+            set_sqlite_error(ctx, "mv_nslock_release: owner argument is required");
+            return;
+        }
+    };
+
+    let db = sqlite_c::sqlite3_context_db_handle(ctx);
+    let mut conn = get_conn(db, &selected_db);
+    let io = conn.io.clone();
+    match io.run(conn.inner.nslock_release(owner, mode)) {
+        Ok(()) => sqlite_c::sqlite3_result_null(ctx),
+        Err(e) => set_sqlite_error(ctx, &format!("{}", e)),
+    }
 }
 
 #[no_mangle]


### PR DESCRIPTION
## Summary

This PR adds SQL-level namespace lock management to mvsqlite, allowing applications to acquire and release namespace locks directly via SQL functions rather than only through environment variables or HTTP APIs. It also refactors the mvclient to support runtime lock owner changes per connection.

## Key Changes

- **Runtime lock owner management in mvclient**: 
  - Added `RwLock<Option<String>>` field to `MultiVersionClient` to track the effective lock owner separately from config
  - Added `lock_owner()` getter and `set_lock_owner()` setter methods to allow per-connection lock owner updates
  - Updated `/stat` and `/batch/commit` request paths to read the current lock owner at request time rather than at initialization

- **New SQL functions in mvsqlite**:
  - `mv_nslock_acquire(db, owner)` and `mv_nslock_acquire(db, owner, version)` — acquire a namespace lock and update the connection's effective lock owner
  - `mv_nslock_release_commit(db, owner)` — release the lock in commit mode
  - `mv_nslock_release_rollback(db, owner)` — release the lock in rollback mode (discarding all writes since acquire)
  - All three functions are `SQLITE_DIRECTONLY` and return `NULL` on success or a SQL error on failure

- **New outcome types in mvclient**:
  - `NslockAcquireOutcome` enum with variants: `Acquired`, `HeldByOther`, `InvalidOwner`, `Rejected`
  - `NslockReleaseOutcome` enum with variants: `Released`, `LockGone`, `OwnerMismatch`, `RollbackInProgress`, `InvalidOwner`, `Rejected`
  - `NslockReleaseMode` enum with `Commit` and `Rollback` variants

- **New HTTP endpoints in mvclient**:
  - `nslock_acquire()` async method that posts to `/nslock/acquire`
  - `nslock_release()` async method that posts to `/nslock/release`
  - Added `request_and_check_returning_status_with_response()` helper to preserve response headers and body for 4xx errors (needed to inspect `x-lock-owner` header)

- **mvfs integration**:
  - Added `nslock_acquire()` and `nslock_release()` methods to `Connection` that wrap the mvclient calls and manage the connection's effective lock owner
  - Both methods error if a SQLite transaction is currently active

- **Documentation**:
  - Updated `docs/nslock.md` with SQL function signatures and usage examples
  - Documented the difference between environment variable (process-wide) and SQL function (per-connection) approaches
  - Added typical usage patterns for both HTTP and SQL paths

## Notable Implementation Details

- Lock owner changes are scoped to a single `MultiVersionClient` instance (one per VFS connection), not shared across sibling connections
- The SQL functions validate that owner strings are valid UTF-8 and reject invalid UTF-8 rather than silently replacing with U+FFFD, since owner strings act as a capability that gates rollback
- Idempotent re-acquire is supported: calling `mv_nslock_acquire` with the same owner while already holding the lock succeeds without changing the snapshot version
- The 409 response code from `/nslock/acquire` is disambiguated by the presence of the `x-lock-owner` header to distinguish between "held by other owner" vs. "unsuitable version"

https://claude.ai/code/session_016FLYqpfDvAnP6eCBEgt2cZ